### PR TITLE
chore(jellyfin): Replace Deprecated Authorization Header

### DIFF
--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -39,10 +39,10 @@ class Jellyfin(Base):
 
     def get_base_header(self) -> dict:
         headers = {
-            "X-Emby-Authorization": self.AUTH_HEADER
+            "Authorization": self.AUTH_HEADER
         }
         if token := self.get_property('accessToken'):
-            headers["X-Emby-Authorization"] += ', Token="{}"'.format(token)
+            headers["Authorization"] += ', Token="{}"'.format(token)
         return headers
 
     def get_url(self, action:str, **keys) -> str:


### PR DESCRIPTION
Jellyfin appears to have moved to a simple `Authorization` header at some point, and has deprecated the `X-Emby-Authorization` header according to the following issue: https://github.com/jellyfin/jellyfin/issues/12990

A Jellyfin project member appears to recommend [this document](https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f) for detailing Authorization, as the web documentation seems to be outdated.

> Disclaimer:
This code change was originally suggested to me by an AI-assisted tool. I have personally tested and confirmed that everything still works as expected with this change.