### PR TITLE
fix: lyrics float conversion error

### DIFF
--- a/src/widgets/lyrics/helpers.py
+++ b/src/widgets/lyrics/helpers.py
@@ -31,10 +31,11 @@ def prepare_lrc(lrc_str:str) -> list:
 
 def list_to_lrc_str(lrc_list:list) -> str:
     lrc_lines = []
-    for item in lyrics_list:
-        minutes = item.get('ms', 0) // 60000
-        seconds = (item.get('ms', 0) % 60000) // 1000
-        centiseconds = (item.get('ms', 0) % 1000) // 10
+    for item in lrc_list:
+        ms = int(item.get('ms', 0))
+        minutes = ms // 60000
+        seconds = (ms % 60000) // 1000
+        centiseconds = (ms % 1000) // 10
 
         timestamp = f"[{minutes:02d}:{seconds:02d}.{centiseconds:02d}]"
         lrc_lines.append(f"{timestamp} {item.get('content').strip()}")
@@ -70,7 +71,7 @@ def get_lyrics(song_id:str, lrclib_download:bool) -> dict:
     plain_lyrics_path = os.path.join(lyrics_dir, file_name_without_ext+'.txt')
 
     if not lrclib_download:
-        result =  integration.getLyrics(song_id)
+        result = integration.getLyrics(song_id)
         if result.get('type') != 'not-found':
             if result.get('type') == 'lrc':
                 with open(lrc_path, 'w+') as f:


### PR DESCRIPTION
Fixes #49 

Fixed an outdated/incorrect variable name being referenced, as well as a float conversion issue that was preventing the lyrics widget from being rendered.

Before, the lyrics view would just show an infinitely spinning loading icon. Now, the proper lyrics widget renders:
<img width="500" alt="Screenshot 2026-03-30 at 12 25 59 am" src="https://github.com/user-attachments/assets/39b3dd58-07c2-46c3-af0e-c0fc87306123" />

> Disclaimer:
> An AI/LLM tool was used in the development of this pull request. I have personally tested and confirmed that the code in this pull request functions as expected. ^^