### PR TITLE
fix: saved login details would revert to default on open

### DIFF
--- a/src/widgets/pages/login.py
+++ b/src/widgets/pages/login.py
@@ -29,7 +29,6 @@ class LoginPage(Adw.NavigationPage):
         saved_user = settings.get_value('integration-user').unpack()
         saved_directory = settings.get_value('integration-library-dir').unpack()
         saved_ip = settings.get_value('integration-ip').unpack()
-        saved_password = secret.get_plain_password() or ""
 
         # Metadata
         metadata = self.integration.login_page_metadata
@@ -46,11 +45,11 @@ class LoginPage(Adw.NavigationPage):
 
         # User
         self.user_el.set_visible('user' in metadata.get('entries'))
-        self.user_el.set_text(saved_user or metadata.get("default-user", ""))
+        self.user_el.set_text(saved_user)
 
         # Password
         self.password_el.set_visible('password' in metadata.get('entries'))
-        self.password_el.set_text(saved_password or metadata.get("default-password", ""))
+        self.password_el.set_text('')
 
         # Directory
         self.directory_el.set_visible('library-dir' in metadata.get('entries'))


### PR DESCRIPTION
Fixes #54

When opening the app, I would be kicked back to the login screen and had to input my Jellyfin server IP + password every time because they'd default back to the fallbacks. This made constantly relaunching while coding fairly annoying 😅.

This PR fixes the flow so the server IP and password are loaded and filled from the secret store, causing the background refresh/login task to no longer fail on startup.

> Disclaimer:
> An AI tool was used in the development of this PR. I've however tested and confirmed that the code in this pull request functions as intended.