### PR TITLE
fix: Guard Artist IDs, Cover Art Request Exception Thread Bubbling

### DIFF
--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -114,13 +114,20 @@ class Jellyfin(Base):
                     'maxWidth': 720,
                     'quality': 90
                 }
-                response = requests.get(
-                    self.get_url('Items/{id}/Images/Primary', id=id),
-                    headers=self.get_base_header(),
-                    params=params,
-                    verify=not self.get_property('trust_server')
-                )
-                response_bytes = response.content if response.status_code == 200 else b''
+                try:
+                    response = requests.get(
+                        self.get_url('Items/{id}/Images/Primary', id=id),
+                        headers=self.get_base_header(),
+                        params=params,
+                        verify=not self.get_property('trust_server'),
+                        timeout=10
+                    )
+                    # Treat non-200 responses as empty content to avoid
+                    # propagating network-related exceptions up and into the UI thread
+                    response.raise_for_status()
+                    response_bytes = response.content
+                except Exception:
+                    response_bytes = b''
 
                 if response_bytes and len(response_bytes) > 0:
                     try:
@@ -426,7 +433,7 @@ class Jellyfin(Base):
                 album=song.get("Album"),
                 albumId=song.get("AlbumId"),
                 artist=song.get("AlbumArtist"),
-                artistId=song.get("ArtistItems", [{}])[0].get("Id"),
+                artistId=(song.get("ArtistItems") or [{}])[0].get("Id"),
                 duration=duration,
                 artists=[{"id": art.get("Id"), "name": art.get("Name")} for art in song.get("ArtistItems", [])],
                 starred=song.get("UserData", {}).get("IsFavorite", False),
@@ -542,7 +549,7 @@ class Jellyfin(Base):
                 "album": song.get("Album"),
                 "albumId": song.get("AlbumId"),
                 "artist": song.get("AlbumArtist"),
-                "artistId": song.get("ArtistItems", [{}])[0].get("Id"),
+                "artistId": (song.get("ArtistItems") or [{}])[0].get("Id"),
                 "duration": duration,
                 "artists": [{"id": art.get("Id"), "name": art.get("Name")} for art in song.get("ArtistItems", [])],
                 "starred": song.get("UserData", {}).get("IsFavorite", False)
@@ -577,7 +584,7 @@ class Jellyfin(Base):
                 "album": song.get("Album"),
                 "albumId": song.get("AlbumId"),
                 "artist": song.get("AlbumArtist"),
-                "artistId": song.get("ArtistItems", [{}])[0].get("Id"),
+                "artistId": (song.get("ArtistItems") or [{}])[0].get("Id"),
                 "duration": duration,
                 "artists": [{"id": art.get("Id"), "name": art.get("Name")} for art in song.get("ArtistItems", [])],
                 "starred": song.get("UserData", {}).get("IsFavorite", False)


### PR DESCRIPTION
– Guard <code>ArtistItems</code> potentially returning <code>None</code> (TypeError/IndexError), with fallback to <code>Id</code>
<details>
<summary>Guard song/album item cover art from HTTP errors/timeouts from causing exceptions bubbling back up to the UI thread</summary>
<pre><code>Exception in thread Thread-423 (getCoverArt):
Traceback (most recent call last):
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/urllib3/response.py", line 903, in _error_catcher
    yield
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/urllib3/response.py", line 1049, in _raw_read
    raise IncompleteRead(self._fp_bytes_read, self.length_remaining)
urllib3.exceptions.IncompleteRead: IncompleteRead(65536 bytes read, 8121 more expected)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/requests/models.py", line 822, in generate
    yield from self.raw.stream(chunk_size, decode_content=True)
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/urllib3/response.py", line 1257, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/urllib3/response.py", line 1149, in read
    data = self._raw_read(amt)
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/urllib3/response.py", line 1027, in _raw_read
    with self._error_catcher():
         ~~~~~~~~~~~~~~~~~~~^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.12_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/urllib3/response.py", line 927, in _error_catcher
    raise ProtocolError(arg, e) from e
urllib3.exceptions.ProtocolError: ('Connection broken: IncompleteRead(65536 bytes read, 8121 more expected)', IncompleteRead(65536 bytes read, 8121 more expected))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.12_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1044, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.12_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 995, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kurisu/.local/share/nocturne/nocturne/integrations/jellyfin.py", line 117, in getCoverArt
    response = requests.get(
        self.get_url('Items/{id}/Images/Primary', id=id),
    ...<2 lines>...
        verify=not self.get_property('trust_server')
    )
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/requests/sessions.py", line 592, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/requests/sessions.py", line 749, in send
    r.content
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/requests/models.py", line 904, in content
    self._content = b"".join(self.iter_content(CONTENT_CHUNK_SIZE)) or b""
                    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kurisu/Developer/Nocturne/.venv/lib/python3.13/site-packages/requests/models.py", line 824, in generate
    raise ChunkedEncodingError(e)
requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(65536 bytes read, 8121 more expected)', IncompleteRead(65536 bytes read, 8121 more expected))
</code></pre></details>