### PR TITLE
feat: Add Nextcloud Music Subsonic support

### DIFF
--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -9,6 +9,7 @@ from PIL import Image
 
 class Navidrome(Base):
     __gtype_name__ = 'NocturneIntegrationNavidrome'
+    _use_plain_password_auth = False
 
     login_page_metadata = {
         'icon-name': "music-note-symbolic",
@@ -25,32 +26,41 @@ class Navidrome(Base):
     user = GObject.Property(type=str)
 
     def get_base_params(self) -> dict:
-        salt, token = secret.get_hashed_password()
-        return {
+        params = {
             'u': self.get_property('user'),
-            't': token,
-            's': salt,
             'v': '1.16.1',
             'c': 'Nocturne',
             'f': 'json'
         }
+        if self._use_plain_password_auth:
+            params['p'] = secret.get_plain_password()
+        else:
+            salt, token = secret.get_hashed_password()
+            params['t'] = token
+            params['s'] = salt
+        return params
 
     def get_url(self, action:str) -> str:
         return '{}/rest/{}'.format(self.get_property('url').strip('/'), action)
 
+    def send_request(self, action: str, params:dict={}) -> requests.Response:
+        return requests.get(
+            self.get_url(action),
+            params={**self.get_base_params(), **params},
+            verify=not self.get_property('trust_server')
+        )
+
     def make_request(self, action:str, params:dict={}) -> dict:
-        params = {
-            **self.get_base_params(),
-            **params
-        }
         try:
-            response = requests.get(
-                self.get_url(action),
-                params=params,
-                verify=not self.get_property('trust_server')
-            )
+            response = self.send_request(action, params)
             if response.status_code == 200:
-                return response.json().get('subsonic-response', {})
+                data = response.json().get('subsonic-response', {})
+                if data.get('status') == 'failed' and data.get('error', {}).get('code') == 41:
+                    self._use_plain_password_auth = True
+                    response = self.send_request(action, params)
+                    if response.status_code == 200:
+                        return response.json().get('subsonic-response', {})
+                return data
         except Exception:
             pass
         return {}


### PR DESCRIPTION
Related to this feature request: #21 

The reason Nextcloud Music's Subsonic Server does not currently work with the app is because it's developers decided the password based authentication was more secure back in 2019.

> (*) The way the token-based authentication is implemented in the Subsonic API, actually makes this new method less secure than the traditional authentication by password. This is because it forces the server to store the passwords in plain text instead of storing just hashes. Also, using the salt like this would protect against eavesdropping only if the server would ensure that the same salt is not reused on another request. This, on the other hand, would basically require saving all the salts ever used! Even the real Subsonic server doesn't seem to make any effort to prevent reusing the same salt.

source: owncloud/music#718

The Subsonic API has an specific error code (41) for servers not supporting token based auth, and I confirmed Nextcloud Music includes it in the response when doing a ping with a valid token and salt:

```json
{
  "subsonic-response": {
    "error": {
      "code": 41,
      "message": "Token-based authentication not supported"
    },
    "status": "failed",
    "version": "1.16.1",
    "type": "nextcloud music",
    "serverVersion": "3.0.0",
    "openSubsonic": true
  }
}
```

This code adds fallback to use plain password auth only when the subsonic server explicitly specifies it doesn't support token based auth with the 41 error code.

I compiled the app and tested it with my Nextcloud Music instance and a newly created Navidrome instance and it authenticated correctly in both cases.