### PR TITLE
feat: Implement 'Now Playing' scrobbling for Navidrome (Subsonic) and ListenBrainz

### DIFF
--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -211,12 +211,12 @@ class Base(GObject.Object):
         # see navidrome.py for example
         print('WARNING', 'downloadSong', 'not implemented')
 
-    def scrobble(self, model_id:str):
+    def scrobble(self, model_id:str, submission:bool=True):
         # the id is for a Song, this is how views are stored
         # called when a song is played
         # if you need to inherit this, also call super().scrobble(id) so that listenbrainz can also get the scrobble
 
-        if model := self.loaded_models.get(id):
+        if submission and (model := self.loaded_models.get(model_id)):
             if token := secret.get_plain_password("listenbrainz"):
                 payload = {
                     "listen_type": "single",

--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -216,12 +216,12 @@ class Base(GObject.Object):
         # called when a song is played
         # if you need to inherit this, also call super().scrobble(id) so that listenbrainz can also get the scrobble
 
-        if submission and (model := self.loaded_models.get(model_id)):
+        if model := self.loaded_models.get(model_id):
             if token := secret.get_plain_password("listenbrainz"):
                 payload = {
-                    "listen_type": "single",
+                    "listen_type": "single" if submission else "playing_now",
                     "payload": [{
-                        "listened_at": int(time.time()),
+                        "listened_at": int(time.time() - (self.loaded_models.get('currentSong').get_property('positionSeconds') or 0)),
                         "track_metadata": {
                             "artist_name": model.get_property("artist"),
                             "track_name": model.get_property("title"),

--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -218,21 +218,25 @@ class Base(GObject.Object):
 
         if model := self.loaded_models.get(model_id):
             if token := secret.get_plain_password("listenbrainz"):
+                listen_payload = {
+                    "track_metadata": {
+                        "artist_name": model.get_property("artist"),
+                        "track_name": model.get_property("title"),
+                        "release_name": model.get_property("album"),
+                        "additional_info": {
+                            "submission_client": "com.jeffser.Nocturne",
+                            "submission_client_version": get_nocturne_version(),
+                            "media_player": "Nocturne"
+                        }
+                    }
+                }
+                
+                if submission:
+                    listen_payload["listened_at"] = int(time.time() - (self.loaded_models.get('currentSong').get_property('positionSeconds') or 0))
+
                 payload = {
                     "listen_type": "single" if submission else "playing_now",
-                    "payload": [{
-                        "listened_at": int(time.time() - (self.loaded_models.get('currentSong').get_property('positionSeconds') or 0)),
-                        "track_metadata": {
-                            "artist_name": model.get_property("artist"),
-                            "track_name": model.get_property("title"),
-                            "release_name": model.get_property("album"),
-                            "additional_info": {
-                                "submission_client": "com.jeffser.Nocturne",
-                                "submission_client_version": get_nocturne_version(),
-                                "media_player": "Nocturne"
-                            }
-                        }
-                    }]
+                    "payload": [listen_payload]
                 }
                 headers = {
                     "Authorization": f"Token {token}",

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -478,8 +478,8 @@ class Local(Base):
             shutil.copy2(source_path, os.path.join(DOWNLOADS_DIR, '{}{}'.format(file_title, extension)))
             progress_callback(1)
 
-    def scrobble(self, model_id:str):
-        if not model_id:
+    def scrobble(self, model_id:str, submission:bool=True):
+        if not model_id or not submission:
             return
         if model := self.loaded_models.get(model_id):
             if model.get_property('isExternalFile') or model.get_property('isRadio'):
@@ -501,7 +501,7 @@ class Local(Base):
 
             with open(os.path.join(self.getIntegrationDir(), 'scrobble.json'), 'w') as f:
                 json.dump(scrobble_dict, f, ensure_ascii=False)
-        super().scrobble(model_id)
+        super().scrobble(model_id, submission=submission)
 
     def setRating(self, model_id:str, rating:int=0) -> bool:
         ratings = self.open_json('ratings.json')
@@ -549,4 +549,3 @@ class Offline(Local):
             pass
 
         return server_information
-

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -479,28 +479,30 @@ class Local(Base):
             progress_callback(1)
 
     def scrobble(self, model_id:str, submission:bool=True):
-        if not model_id or not submission:
+        if not model_id:
             return
         if model := self.loaded_models.get(model_id):
             if model.get_property('isExternalFile') or model.get_property('isRadio'):
                 return
-            scrobble_dict = self.open_json('scrobble.json')
+            
+            if submission:
+                scrobble_dict = self.open_json('scrobble.json')
 
-            if model_id in scrobble_dict:
-                scrobble_dict[model_id]['plays'] += 1
-                scrobble_dict[model_id]['last_play'] = int(time.time())
-                scrobble_dict[model_id]['album'] = model.get_property('albumId')
-                scrobble_dict[model_id]['artist'] = model.get_property('artistId')
-            else:
-                scrobble_dict[model_id] = {
-                    'plays': 1,
-                    'last_play': int(time.time()),
-                    'album': model.get_property('albumId'),
-                    'artist': model.get_property('artistId')
-                }
+                if model_id in scrobble_dict:
+                    scrobble_dict[model_id]['plays'] += 1
+                    scrobble_dict[model_id]['last_play'] = int(time.time())
+                    scrobble_dict[model_id]['album'] = model.get_property('albumId')
+                    scrobble_dict[model_id]['artist'] = model.get_property('artistId')
+                else:
+                    scrobble_dict[model_id] = {
+                        'plays': 1,
+                        'last_play': int(time.time()),
+                        'album': model.get_property('albumId'),
+                        'artist': model.get_property('artistId')
+                    }
 
-            with open(os.path.join(self.getIntegrationDir(), 'scrobble.json'), 'w') as f:
-                json.dump(scrobble_dict, f, ensure_ascii=False)
+                with open(os.path.join(self.getIntegrationDir(), 'scrobble.json'), 'w') as f:
+                    json.dump(scrobble_dict, f, ensure_ascii=False)
         super().scrobble(model_id, submission=submission)
 
     def setRating(self, model_id:str, rating:int=0) -> bool:

--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -486,14 +486,15 @@ class Navidrome(Base):
         except:
             pass
 
-    def scrobble(self, model_id:str):
+    def scrobble(self, model_id:str, submission:bool = True):
         # Registers the song as played, useful for keeping track of "most played" albums and the sorts
         if model := self.loaded_models.get(model_id) :
             if not model.isExternalFile:
                 self.make_request('scrobble', {
-                    'id': model_id
+                    'id': model_id,
+                    'submission': submission
                 })
-        super().scrobble(model_id)
+        super().scrobble(model_id, submission)
 
     def getServerInformation(self) -> dict:
         server_information = {

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -335,8 +335,13 @@ class Player(EventAdapter):
         integration = get_current_integration()
         current_song_id = integration.loaded_models.get('currentSong').songId
 
-        if action == "end" and current_song_id:
-            threading.Thread(target=integration.scrobble, args=(current_song_id,)).start()
+        if current_song_id:
+            position = integration.loaded_models.get('currentSong').get_property('positionSeconds')
+            song = integration.loaded_models.get(current_song_id)
+            duration = song.get_property('duration') if song else 0
+
+            if action == "end" or (duration > 0 and position >= (duration / 2)):
+                threading.Thread(target=integration.scrobble, args=(current_song_id,)).start()
 
         mode = self.settings.get_value('playback-mode').unpack()
 

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -335,6 +335,9 @@ class Player(EventAdapter):
         integration = get_current_integration()
         current_song_id = integration.loaded_models.get('currentSong').songId
 
+        if action == "end" and current_song_id:
+            threading.Thread(target=integration.scrobble, args=(current_song_id,)).start()
+
         mode = self.settings.get_value('playback-mode').unpack()
 
         if action != "end" and mode == "repeat-one":
@@ -514,9 +517,7 @@ class Player(EventAdapter):
                     self.pause_next_change = False
                 else:
                     self.gst.set_state(Gst.State.PLAYING)
-                threading.Thread(target=integration.scrobble, args=(song_id,)).start()
+                threading.Thread(target=integration.scrobble, args=(song_id,), kwargs={'submission': False}).start()
                 threading.Thread(target=update_default_metadata, args=(song_id,)).start()
         else:
             self.gst.set_state(Gst.State.NULL)
-
-


### PR DESCRIPTION
Resolves #116

This pull requests adds the 'Now playing' scrobble to both the Subsonic server and Listenbrainz.

It has some behavior changes.

| Event | Service | Current Behavior | New Behavior |
| :--- | :--- | :--- | :--- |
| Playback Starts | Subsonic | `submission = True` (Increments play count immediately) | `submission = False` (Updates "Now Playing" only) |
| | ListenBrainz | `listen_type = 'single'` (Marks as listened) | `listen_type = 'playing_now'` (Status update only) |
| Song Completion (or skip at >50% play) | Both | *No secondary action* | Sends final scrobble (`submission = True` & `listen_type = single`) to commit to history |

Additionally, it has the following consequences:

- If a song is skipped after a few seconds, it will no longer be scrobbled
- If the user closes the app before the song finishes, it won't be scrobbled either