### PR TITLE
fix: null replayGain and missing lyrics errors with Nextcloud Music

### DIFF
--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -331,7 +331,8 @@ class Navidrome(Base):
         return [s.get('id') for s in songs if s.get('id')]
 
     def getLyrics(self, songId:str) -> dict:
-        lyrics = self.make_request('getLyricsBySongId', {'id': songId}).get('lyricsList', {}).get('structuredLyrics', [{}])[0]
+        lyrics_data = self.make_request('getLyricsBySongId', {'id': songId}).get('lyricsList') or {}
+        lyrics = (lyrics_data.get('structuredLyrics') or [{}])[0]
 
         if lyrics.get('synced', False):
             lrc_lines = []

--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -259,7 +259,7 @@ class Navidrome(Base):
         def update():
             response = self.make_request('getSong', {'id': model_id})
             song_dict = response.get('song', {})
-            gains = song_dict.get('replayGain')
+            gains = song_dict.get('replayGain') or {}
             self.loaded_models[model_id].update_data(**song_dict, albumGain=gains.get('albumGain', 0.0), trackGain=gains.get('trackGain', 0.0))
             threading.Thread(target=self.getCoverArt, args=(model_id,)).start()
 


### PR DESCRIPTION
The parameter replayGain is not available when using the app with Nextcloud Music.

`
File "/app/share/nocturne/nocturne/integrations/navidrome.py", line 263, in update
    self.loaded_models[model_id].update_data(**song_dict, albumGain=gains.get('albumGain', 0.0), trackGain=gains.get('trackGain', 0.0))
                                                                    ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
`

Similarily, there was an error when playing a song with no lyrics data:

`
File "/app/share/nocturne/nocturne/integrations/navidrome.py", line 334, in getLyrics
    lyrics = self.make_request('getLyricsBySongId', {'id': songId}).get('lyricsList', {}).get('structuredLyrics', [{}])[0]
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
`

This pull request adds a default values to `gains`  and `lyrics` to prevent these errors.