### PR TITLE
fix: MPRIS cover art not updating and unknown artist

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -37,7 +37,7 @@ if os.path.isdir(OLD_LOCAL_DATA_DIR) and not os.path.isdir(os.path.join(INTEGRAT
     os.rename(OLD_LOCAL_DATA_DIR, os.path.join(INTEGRATIONS_DIR, 'NocturneIntegrationLocal'))
 # ----------
 
-MPRIS_COVER_PATH = os.path.join(CACHE_DIR, 'cover.png')
+MPRIS_COVER_PATH = os.path.join(CACHE_DIR, 'cover')
 DOWNLOAD_QUEUE_DIR = os.path.join(DATA_DIR, 'downloading')
 if os.path.isdir(DOWNLOAD_QUEUE_DIR):
     shutil.rmtree(DOWNLOAD_QUEUE_DIR)

--- a/src/widgets/playing/control_page.py
+++ b/src/widgets/playing/control_page.py
@@ -3,7 +3,7 @@
 from gi.repository import Gtk, Adw, Gdk, GLib, GObject, Gst, Gio
 from ...integrations import get_current_integration
 from ...constants import MPRIS_COVER_PATH, get_display_time
-import threading, random, io, colorsys, os, base64
+import threading, random, io, colorsys, os, base64, glob
 from PIL import Image, ImageFilter
 from colorthief import ColorThief
 from urllib.parse import urlparse
@@ -248,6 +248,9 @@ class PlayingControlPage(Adw.NavigationPage):
             identifier = (song.get_property('albumId') or song_id).replace('/', '_')
             mpris_path = f"{MPRIS_COVER_PATH}_{identifier}"
             
+            for old_file in glob.glob(f"{MPRIS_COVER_PATH}_*"):
+                os.remove(old_file)
+
             gbytes, paintable = integration.getCoverArt(song_id)
             if gbytes:
                 threading.Thread(target=self.update_palette, args=(bytes(gbytes.get_data()),)).start()
@@ -258,8 +261,6 @@ class PlayingControlPage(Adw.NavigationPage):
             else:
                 GLib.idle_add(self.cover_el.set_paintable, None)
                 GLib.idle_add(self.cover_el.set_visible, False)
-                if os.path.isfile(mpris_path):
-                    os.remove(mpris_path)
 
     def update_starred(self, starred:bool):
         if starred:

--- a/src/widgets/playing/control_page.py
+++ b/src/widgets/playing/control_page.py
@@ -244,10 +244,8 @@ class PlayingControlPage(Adw.NavigationPage):
         integration = get_current_integration()
         song_id = integration.loaded_models.get('currentSong').get_property('songId')
         if song_id:
-            song = integration.loaded_models.get(song_id)
-            identifier = (song.get_property('albumId') or song_id).replace('/', '_')
-            mpris_path = f"{MPRIS_COVER_PATH}_{identifier}"
-            
+            mpris_path = f"{MPRIS_COVER_PATH}_{song_id.replace('/', '_')}"
+
             for old_file in glob.glob(f"{MPRIS_COVER_PATH}_*"):
                 os.remove(old_file)
 

--- a/src/widgets/playing/control_page.py
+++ b/src/widgets/playing/control_page.py
@@ -244,18 +244,22 @@ class PlayingControlPage(Adw.NavigationPage):
         integration = get_current_integration()
         song_id = integration.loaded_models.get('currentSong').get_property('songId')
         if song_id:
+            song = integration.loaded_models.get(song_id)
+            identifier = (song.get_property('albumId') or song_id).replace('/', '_')
+            mpris_path = f"{MPRIS_COVER_PATH}_{identifier}"
+            
             gbytes, paintable = integration.getCoverArt(song_id)
             if gbytes:
                 threading.Thread(target=self.update_palette, args=(bytes(gbytes.get_data()),)).start()
             if paintable:
                 GLib.idle_add(self.cover_el.set_paintable, paintable)
                 GLib.idle_add(self.cover_el.set_visible, True)
-                paintable.save_to_png(MPRIS_COVER_PATH)
+                paintable.save_to_png(mpris_path)
             else:
                 GLib.idle_add(self.cover_el.set_paintable, None)
                 GLib.idle_add(self.cover_el.set_visible, False)
-                if os.path.isfile(MPRIS_COVER_PATH):
-                    os.remove(MPRIS_COVER_PATH)
+                if os.path.isfile(mpris_path):
+                    os.remove(mpris_path)
 
     def update_starred(self, starred:bool):
         if starred:

--- a/src/widgets/playing/control_page.py
+++ b/src/widgets/playing/control_page.py
@@ -244,9 +244,9 @@ class PlayingControlPage(Adw.NavigationPage):
         integration = get_current_integration()
         song_id = integration.loaded_models.get('currentSong').get_property('songId')
         if song_id:
-            mpris_path = f"{MPRIS_COVER_PATH}_{song_id.replace('/', '_')}"
+            mpris_path = f"{MPRIS_COVER_PATH}_{song_id.replace('/', '_')}.png"
 
-            for old_file in glob.glob(f"{MPRIS_COVER_PATH}_*"):
+            for old_file in glob.glob(f"{MPRIS_COVER_PATH}_*.png"):
                 os.remove(old_file)
 
             gbytes, paintable = integration.getCoverArt(song_id)

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -63,7 +63,7 @@ class PlayerAdapter(MprisAdapter):
         if not song:
             return MetadataObj()
 
-        mpris_path = f"{MPRIS_COVER_PATH}_{song.get_property('id').replace('/', '_')}"
+        mpris_path = f"{MPRIS_COVER_PATH}_{song.get_property('id').replace('/', '_')}.png"
         return MetadataObj(
             album=song.get_property('album'),
             art_url='file://{}'.format(mpris_path),

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -66,7 +66,7 @@ class PlayerAdapter(MprisAdapter):
         return MetadataObj(
             album=song.get_property('album'),
             art_url='file://{}'.format(MPRIS_COVER_PATH),
-            artists=[urlparse(song.get_property('streamUrl')).netloc.capitalize()] if song.get_property('isRadio') and song.get_property('streamUrl') else [a.get('name') for a in song.get_property('artists')],
+            artists=[urlparse(song.get_property('streamUrl')).netloc.capitalize()] if song.get_property('isRadio') and song.get_property('streamUrl') else ([a.get('name') for a in song.get_property('artists')] or [song.get_property('artist')]),
             as_text=[song.get_property('title')],
             length=song.get_property('duration')*1000000,
             title=song.get_property('title'),

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -63,8 +63,7 @@ class PlayerAdapter(MprisAdapter):
         if not song:
             return MetadataObj()
 
-        identifier = (song.get_property('albumId') or song.get_property('id')).replace('/', '_')
-        mpris_path = f"{MPRIS_COVER_PATH}_{identifier}"
+        mpris_path = f"{MPRIS_COVER_PATH}_{song.get_property('id').replace('/', '_')}"
         return MetadataObj(
             album=song.get_property('album'),
             art_url='file://{}'.format(mpris_path),

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -63,9 +63,11 @@ class PlayerAdapter(MprisAdapter):
         if not song:
             return MetadataObj()
 
+        identifier = (song.get_property('albumId') or song.get_property('id')).replace('/', '_')
+        mpris_path = f"{MPRIS_COVER_PATH}_{identifier}"
         return MetadataObj(
             album=song.get_property('album'),
-            art_url='file://{}'.format(MPRIS_COVER_PATH),
+            art_url='file://{}'.format(mpris_path),
             artists=[urlparse(song.get_property('streamUrl')).netloc.capitalize()] if song.get_property('isRadio') and song.get_property('streamUrl') else ([a.get('name') for a in song.get_property('artists')] or [song.get_property('artist')]),
             as_text=[song.get_property('title')],
             length=song.get_property('duration')*1000000,


### PR DESCRIPTION
Fixes #108

This pull request adds an identifier (albumId or songId) to `MPRIS_COVER_PATH` to avoid caching issues that prevented the new cover art from showing up.

There is one disadvantage, now there will be a cached cover art per album, but it's very likely that change won't be negatively impactful even with thousands of albums.

Also, the MPRIS player showing 'Unknown Artist' for Nextcloud Music servers was corrected, adding a fallback to `song.artist` if `song.artists` is unavailable.