### PR TITLE
fix: show correct album artist in local integration

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -118,13 +118,14 @@ def get_song_info_from_file(file_path:str, star_dict:dict={}, is_external_file:b
     tag = TinyTag.get(file_path)
     if not tag:
         return None
+    album_artist = (tag.albumartist or tag.artist or "").split(';')[0].strip()
     song = {
         'path': file_path,
         'coverArt': file_path,
         'duration': tag.duration or 0,
         'title': tag.title or os.path.basename(file_path),
         'album': tag.album or "",
-        'artist': tag.artist.split(';')[0] or "",
+        'artist': album_artist,
         'artists': [{
             'id': "ARTIST:{}".format(art.strip()),
             'name': art.strip(),
@@ -138,7 +139,7 @@ def get_song_info_from_file(file_path:str, star_dict:dict={}, is_external_file:b
     }
 
     if not is_external_file:
-        song["artistId"] = "ARTIST:{}".format(song.get("artist")) if song.get('artist') else ""
+        song["artistId"] = "ARTIST:{}".format(album_artist) if album_artist else ""
         song["albumId"] = "ALBUM:{}".format(song.get("album")) if song.get('album') else ""
 
     return song


### PR DESCRIPTION
In the local integration, the artist of the first song was being taken as the album artist.

<img width="1385" height="885" alt="before_albumartist_fix" src="https://github.com/user-attachments/assets/2cb5c693-9f46-4cd6-9cad-05e32a8673b1" />

<br>
<br>
This pull request fixes that by using the `albumartist` tag.

<img width="1385" height="885" alt="after_albumartist_fix" src="https://github.com/user-attachments/assets/962921e7-db6e-4e15-bfaa-7a50bd8b931c" />

<br>
<br>
The song's artist still show up for each song both in the song lists and the player.