### PR TITLE
fix: missing artists when using with Nextcloud Music

### DIFF
--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -259,7 +259,7 @@ class Navidrome(Base):
         def update():
             response = self.make_request('getSong', {'id': model_id})
             song_dict = response.get('song', {})
-            if 'artists' not in song_dict:
+            if 'artists' not in song_dict and song_dict.get('artistId'):
                 song_dict['artists'] = [{
                     'id': song_dict.get('artistId'),
                     'name': song_dict.get('artist')

--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -259,6 +259,11 @@ class Navidrome(Base):
         def update():
             response = self.make_request('getSong', {'id': model_id})
             song_dict = response.get('song', {})
+            if 'artists' not in song_dict:
+                song_dict['artists'] = [{
+                    'id': song_dict.get('artistId'),
+                    'name': song_dict.get('artist')
+                }]
             gains = song_dict.get('replayGain') or {}
             self.loaded_models[model_id].update_data(**song_dict, albumGain=gains.get('albumGain', 0.0), trackGain=gains.get('trackGain', 0.0))
             threading.Thread(target=self.getCoverArt, args=(model_id,)).start()
@@ -588,5 +593,4 @@ class NavidromeIntegrated(Navidrome):
             self.process.terminate()
             self.process = None
         self.set_property('serverRunning', False)
-
 


### PR DESCRIPTION
Since the `GetSong` endpoint does not return the `artists` field, songs were not showing the artist in the app. It's an old bug I just hadn't noticed until now.

This PR adds a fallback so that `artists` is populated with `artistId` and `artist` from the response in case the field comes empty.