### PR TITLE
Fix typo in readme (it's --> its)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><img src="https://jeffser.com/images/nocturne/logo.svg">
 <h1 align="center">Nocturne</h1>
 
-<p align="center">Nocturne is a Navidrome / Jellyfin client that brings all your music together in one place, Nocturne not only connects to existing instances but it's capable of installing and managing it's own Navidrome instance</p>
+<p align="center">Nocturne is a Navidrome / Jellyfin client that brings all your music together in one place, Nocturne not only connects to existing instances but it's capable of installing and managing its own Navidrome instance</p>
 
 <p align="center"><a href='https://flathub.org/apps/com.jeffser.Nocturne'><img width='190' alt='Download on Flathub' src='https://flathub.org/api/badge?locale=en'/></a></p>
 


### PR DESCRIPTION
"it's" refers to the contraction "it is". We want the ownership form, which is "its"