### PR TITLE
Exclude hidden files when loading local songs

### DIFF
--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -35,6 +35,10 @@ class Local(Base):
             threads = []
             self.set_property('loadingMessage', _("Loading Songs"))
             for file_path in path_obj.rglob("*"):
+                # Exclude any hidden files/folders within the library path
+                if any(part.startswith(".") for part in file_path.relative_to(path_obj).parts):
+                    continue
+
                 if file_path.suffix.lower() in ('.mp3', '.flac', '.m4a', '.ogg', '.wav'):
                     song_id = 'SONG:{}'.format(file_path)
                     self.loaded_models[song_id] = models.Song(id=song_id, path=file_path, coverArt=file_path)


### PR DESCRIPTION
This also aligns with how Rhythmbox behaves for me, and prevents some garbage music files in hidden folders from showing up in my library.