### PR TITLE
feat: Add scanning for .opus and .oga files in the local integration

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -50,6 +50,7 @@ DOWNLOAD_MIME_MAP = {
     "audio/flac": ".flac",
     "audio/x-flac": ".flac",
     "audio/ogg": ".ogg",
+    "audio/opus": ".opus",
     "audio/wav": ".wav",
     "audio/mp4": ".m4a",
     "audio/x-m4a": ".m4a"

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -35,7 +35,7 @@ class Local(Base):
             threads = []
             self.set_property('loadingMessage', _("Loading Songs"))
             for file_path in path_obj.rglob("*"):
-                if file_path.suffix.lower() in ('.mp3', '.flac', '.m4a', '.ogg', '.wav'):
+                if file_path.suffix.lower() in ('.mp3', '.flac', '.m4a', '.oga', '.ogg', '.opus', '.wav'):
                     song_id = 'SONG:{}'.format(file_path)
                     self.loaded_models[song_id] = models.Song(id=song_id, path=file_path, coverArt=file_path)
                     threads.append(threading.Thread(target=self.verifySong, args=(song_id,)))


### PR DESCRIPTION
Resolves #142

This PR adds the .opus and .oga file extensions to the supported list.

.wma was not added since playback was spotty based on my testing, both .oga and .opus songs worked without any issue.