### PR TITLE
fix: Issues with track artists vs. album artist in local integration

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -114,11 +114,24 @@ def get_display_time(seconds:float, show_ms:bool=False) -> str:
         # Format MM:SS.ms
         return f"{minutes:02.0f}:{seconds_str}"
 
+def _normalize_artists(values:list[str]) -> list[str]:
+    artists = []
+    for value in values:
+        for artist_name in value.split(';'):
+            artist_name = artist_name.strip()
+            if artist_name and artist_name not in artists:
+                artists.append(artist_name)
+    return artists
+
 def get_song_info_from_file(file_path:str, star_dict:dict={}, is_external_file:bool=False) -> dict | None:
     tag = TinyTag.get(file_path)
     if not tag:
         return None
-    album_artist = (tag.albumartist or tag.artist or "").split(';')[0].strip()
+
+    artists = _normalize_artists(tag.as_dict().get('artist', []))
+    album_artists = _normalize_artists([tag.albumartist or ""])
+    album_artist = album_artists[0] if album_artists else (artists[0] if artists else "")
+
     song = {
         'path': file_path,
         'coverArt': file_path,
@@ -127,10 +140,10 @@ def get_song_info_from_file(file_path:str, star_dict:dict={}, is_external_file:b
         'album': tag.album or "",
         'artist': album_artist,
         'artists': [{
-            'id': "ARTIST:{}".format(art.strip()),
-            'name': art.strip(),
-            'starred': star_dict.get("ARTIST:{}".format(art.strip()))
-        } for art in tag.artist.split(';')],
+            'id': "ARTIST:{}".format(artist_name),
+            'name': artist_name,
+            'starred': star_dict.get("ARTIST:{}".format(artist_name))
+        } for artist_name in artists],
         'track': tag.track or 0,
         'isExternalFile': is_external_file,
         'discNumber': tag.disc or 0,
@@ -430,4 +443,3 @@ CONTEXT_MANAGED_NAVIDROME_SERVER = {
         "action-name": "app.delete_navidrome_server"
     }
 }
-

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -11,6 +11,7 @@ from ..constants import DOWNLOADS_DIR, get_song_info_from_file
 
 class Local(Base):
     __gtype_name__ = 'NocturneIntegrationLocal'
+    album_artist_ids = set()
 
     login_page_metadata = {
         'icon-name': "folder-open-symbolic",
@@ -29,6 +30,7 @@ class Local(Base):
         # Goes through the whole directory retrieving all the metadata
         audio_data_list = []
         path_obj = pathlib.Path(self.get_property('libraryDir'))
+        self.album_artist_ids = set()
 
         def load_songs():
             # load songs, albums, artists
@@ -167,7 +169,7 @@ class Local(Base):
         return [model_id for model_id in album_list if model_id in self.loaded_models][offset:size+offset]
 
     def getArtists(self, size:int=10) -> list:
-        return [model_id for model_id in list(self.loaded_models) if model_id.startswith('ARTIST:')][:size]
+        return [model_id for model_id in list(self.loaded_models) if model_id in self.album_artist_ids][:size]
 
     def getPlaylists(self) -> list:
         self.load_playlists()
@@ -221,23 +223,30 @@ class Local(Base):
                     self.loaded_models[album.get('id')] = models.Album(**album)
 
             # Making Artist Model
-            artist_id = song.get('artistId')
-            if artist_id:
+            def update_artist(artist_id:str, artist_name:str):
                 if artist_id not in self.loaded_models:
                     self.loaded_models[artist_id] = models.Artist(
                         id=artist_id,
                         coverArt=song.get('path'),
-                        name=song.get('artist'),
+                        name=artist_name,
                         album=[],
                         albumCount=0,
                         starred=artist_id in star_dict
                     )
 
-                # Add album
                 album_list = self.loaded_models.get(artist_id).album
                 if album_id and not any(album.get('id') == album_id for album in album_list):
                     self.loaded_models.get(artist_id).album.append({'id': album_id})
                     self.loaded_models.get(artist_id).albumCount += 1
+
+            artist_id = song.get('artistId')
+            if artist_id:
+                self.album_artist_ids.add(artist_id)
+                update_artist(artist_id, song.get('artist'))
+
+            for artist in song.get('artists', []):
+                if artist.get('id'):
+                    update_artist(artist.get('id'), artist.get('name'))
 
         if force_update or not self.loaded_models.get(model_id).get_property('title'):
             if use_threading:
@@ -325,7 +334,7 @@ class Local(Base):
         return {'type': 'not-found'}
 
     def search(self, query:str, artistCount:int=0, artistOffset:int=0, albumCount:int=0, albumOffset:int=0, songCount:int=0, songOffset:int=0) -> dict:
-        all_artists = [model for model_id, model in self.loaded_models.items() if model_id.startswith('ARTIST:')]
+        all_artists = [model for model_id, model in self.loaded_models.items() if model_id in self.album_artist_ids]
         all_albums = [model for model_id, model in self.loaded_models.items() if model_id.startswith('ALBUM:')]
         all_songs = [model for model_id, model in self.loaded_models.items() if model_id.startswith('SONG:')]
 


### PR DESCRIPTION
Fixes #140

This PR addresses an issue caused by a4527d3a3f41c6045b5fd3416d51c3c03c26a524, where the lack of models for track artists caused a bug when loading their page. The functionality of what was done in a4527d3a3f41c6045b5fd3416d51c3c03c26a524 is preserved, but models for the artists are now created even if they don't appear in the artists page or search.

Also, it adds support for multiple artist and albumartist tags present in flac files, and the app will now show the multiple artists instead of just the first one.