### PR TITLE
feat: Prevent screen from turning off when fullscreen player is activated.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -47,6 +47,7 @@ class NocturneApplication(Adw.Application):
         self.popout_window = None
         self.player = None
         self.inhibit_cookie = None
+        self.idle_inhibit_cookie = None
         self.css_provider = Gtk.CssProvider()
         Gtk.StyleContext.add_provider_for_display(
             Gdk.Display.get_default(),
@@ -73,6 +74,19 @@ class NocturneApplication(Adw.Application):
         if self.inhibit_cookie is not None:
             self.uninhibit(self.inhibit_cookie)
             self.inhibit_cookie = None
+
+    def inhibit_idle(self, window=None):
+        if self.idle_inhibit_cookie is None:
+            self.idle_inhibit_cookie = self.inhibit(
+                window or self.get_active_window(),
+                Gtk.ApplicationInhibitFlags.IDLE,
+                _("Fullscreen Player Active")
+            )
+
+    def uninhibit_idle(self):
+        if self.idle_inhibit_cookie is not None:
+            self.uninhibit(self.idle_inhibit_cookie)
+            self.idle_inhibit_cookie = None
 
     def load_default_integration(self):
         settings = Gio.Settings(schema_id="com.jeffser.Nocturne")

--- a/src/widgets/playing/popout_window.py
+++ b/src/widgets/playing/popout_window.py
@@ -97,6 +97,8 @@ class PopoutWindow(Adw.ApplicationWindow):
 
     @Gtk.Template.Callback()
     def close_request(self, window):
+        if application := self.get_application():
+            application.uninhibit_idle()
         if self.get_application().main_window.get_hide_on_close():
             self.get_application().main_window.present()
 
@@ -164,4 +166,10 @@ class PopoutWindow(Adw.ApplicationWindow):
 
     @Gtk.Template.Callback()
     def fullscreen_toggled(self, window, gparam):
-        self.toggle_fullscreen_el.set_icon_name('view-unfullscreen-symbolic' if window.is_fullscreen() else 'view-fullscreen-symbolic')
+        fullscreen = window.is_fullscreen()
+        self.toggle_fullscreen_el.set_icon_name('view-unfullscreen-symbolic' if fullscreen else 'view-fullscreen-symbolic')
+        if application := self.get_application():
+            if fullscreen:
+                application.inhibit_idle(self)
+            else:
+                application.uninhibit_idle()


### PR DESCRIPTION
Resolves #136

This PR adds a GTK idle inhibition when the fullscreen player is activated to prevent the screen from turning off. It's specially useful when using the fullscreen player with song lyrics.