### PR TITLE
Fix issue with incomplete song models

### DIFF
--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -69,8 +69,9 @@ class Navidrome(Base):
 
     def get_stream_url(self, song_id:str) -> str:
         # streams are handled by gst not requests
-        if song_id not in self.loaded_models:
-            self.verifySong(song_id, use_threading=False)
+        model = self.loaded_models.get(song_id)
+        if not model or (model.get_property('artistId') and not model.get_property('artists')):
+            self.verifySong(song_id, force_update=True, use_threading=False)
         model = self.loaded_models.get(song_id)
 
         if radioStreamUrl := model.get_property('radioStreamUrl'):


### PR DESCRIPTION
Fixes #187
Fixes #183

The artist and cover art was not loading due to a partially loaded song model that didn't include `artists` or `coverArt` (In the case of Nextcloud Music)

This PR addresses that issue by triggering verifySong if the song's model is partially loaded at the moment of playing the song (validated checking if `artists` is not set despite there being a valid `artistId`).