### PR TITLE
Consistent and clear album sorting by release date on artist pages

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -154,6 +154,7 @@ def get_song_info_from_file(file_path:str, star_list:list=[], is_external_file:b
         'track': tag.track or 0,
         'isExternalFile': is_external_file,
         'discNumber': tag.disc or 0,
+        'year':tag.year or 0,
         'albumGain': tag.extra.get('replaygain_album_gain') or tag.extra.get('REPLAYGAIN_ALBUM_GAIN') or 1,
         'trackGain': tag.extra.get('replaygain_track_gain') or tag.extra.get('REPLAYGAIN_TRACK_GAIN') or 1
     }

--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -439,7 +439,7 @@ class Jellyfin(Base):
                         "ParentId": model_id,
                         "IncludeItemTypes": "Audio",
                         "Recursive": "true",
-                        "Fields": "RunTimeTicks,IndexNumber,ParentIndexNumber",
+                        "Fields": "RunTimeTicks,IndexNumber,ParentIndexNumber,ProductionYear",
                         "SortBy": "ParentIndexNumber,IndexNumber",
                         "SortOrder": "Ascending"
                     }
@@ -461,7 +461,8 @@ class Jellyfin(Base):
                     artists=[{"id": art.get("Id"), "name": art.get("Name")} for art in album.get("ArtistItems", [])],
                     song=[{"id": song.get("Id"), "name": song.get("Name")} for song in songs],
                     starred=album.get("UserData", {}).get("IsFavorite", False),
-                    userRating=self.get_rating(album.get("Id"))
+                    userRating=self.get_rating(album.get("Id")),
+                    year=album.get("ProductionYear", 0)
                 )
             elif model_id in self.loaded_models:
                 del self.loaded_models[model_id]

--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -397,8 +397,7 @@ class Jellyfin(Base):
                         "IncludeItemTypes": "MusicAlbum",
                         "Recursive": "true",
                         "Fields": "ItemCounts",
-                        "SortBy": "PremiereDate",
-                        "SortOrder":"Descending"
+                        "SortBy": "PremiereDate"
                     }
                 ).get("Items", [])
 

--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -396,7 +396,9 @@ class Jellyfin(Base):
                         "ParentId": model_id,
                         "IncludeItemTypes": "MusicAlbum",
                         "Recursive": "true",
-                        "Fields": "ItemCounts"
+                        "Fields": "ItemCounts",
+                        "SortBy": "PremiereDate",
+                        "SortOrder":"Descending"
                     }
                 ).get("Items", [])
 

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -281,6 +281,7 @@ class Local(Base):
                         'artist': song.get('artist'),
                         'artistId': song.get('artistId'),
                         'song': [{'id': model_id}],
+                        'year':int(song.get('year') or "0"),
                         'starred': album_id in star_list,
                         'userRating': self.get_rating(album_id)
                     }

--- a/src/integrations/models.py
+++ b/src/integrations/models.py
@@ -17,6 +17,7 @@ class Album(GObject.Object):
     song = GObject.Property(type=GObject.TYPE_PYOBJECT) #list
     starred = GObject.Property(type=bool, default=False)
     userRating = GObject.Property(type=int)
+    year = GObject.Property(type=int)
 
     def __init__(self, **kwargs):
         super().__init__()

--- a/src/ui/album/button.blp
+++ b/src/ui/album/button.blp
@@ -71,7 +71,7 @@ template $NocturneAlbumButton: Gtk.Box {
     };
   }
 
-  Gtk.Button name_el {
+  Gtk.Button name_button_el {
     Gtk.GestureClick {
       button: 3;
       released => $show_popover_name();
@@ -87,15 +87,18 @@ template $NocturneAlbumButton: Gtk.Box {
       label: _("Enter album page");
     }
 
-    child: Gtk.Stack{
-      Gtk.Label title_el {
+    child: Gtk.Box{
+      orientation: vertical;
+      spacing: 6;
+
+      Gtk.Label name_el {
         styles [
           "title-3"
         ]
         ellipsize: end;
         max-width-chars: 1;
       }
-      Gtk.Label subtitle_el {
+      Gtk.Label year_el {
         styles [
           "dimmed"
         ]

--- a/src/ui/album/button.blp
+++ b/src/ui/album/button.blp
@@ -80,7 +80,6 @@ template $NocturneAlbumButton: Gtk.Box {
       pressed => $show_popover_name();
     }
     styles [
-      "title-3",
       "flat",
       "p0"
     ]
@@ -88,9 +87,22 @@ template $NocturneAlbumButton: Gtk.Box {
       label: _("Enter album page");
     }
 
-    child: Gtk.Label {
-      ellipsize: end;
-      max-width-chars: 1;
+    child: Gtk.Stack{
+      Gtk.Label title_el {
+        styles [
+          "title-3"
+        ]
+        ellipsize: end;
+        max-width-chars: 1;
+      }
+      Gtk.Label subtitle_el {
+        styles [
+          "dimmed"
+        ]
+        visible: false;
+        ellipsize: end;
+        max-width-chars: 1;
+      }
     };
 
     action-name: "app.show_album";

--- a/src/widgets/album/button.py
+++ b/src/widgets/album/button.py
@@ -14,6 +14,8 @@ class AlbumButton(Gtk.Box):
     cover_button_el = Gtk.Template.Child()
     cover_el = Gtk.Template.Child()
     name_el = Gtk.Template.Child()
+    title_el = Gtk.Template.Child()
+    subtitle_el = Gtk.Template.Child()
     artist_el = Gtk.Template.Child()
 
     def __init__(self, id:str):
@@ -43,11 +45,11 @@ class AlbumButton(Gtk.Box):
         self.cover_el.set_size_request(size, size)
         self.cover_el.set_pixel_size(pixel_size)
         if isBig:
-            self.name_el.remove_css_class('title-4')
-            self.name_el.add_css_class('title-3')
+            self.title_el.remove_css_class('title-4')
+            self.title_el.add_css_class('title-3')
         else:
-            self.name_el.remove_css_class('title-3')
-            self.name_el.add_css_class('title-4')
+            self.title_el.remove_css_class('title-3')
+            self.title_el.add_css_class('title-4')
 
     def update_cover(self, paintable:Gdk.Paintable=None):
         if paintable:
@@ -57,7 +59,7 @@ class AlbumButton(Gtk.Box):
         self.update_size()
 
     def update_name(self, name:str):
-        self.name_el.get_child().set_label(name)
+        self.title_el.set_label(name)
         self.name_el.set_tooltip_text(name)
         self.cover_button_el.set_tooltip_text(name)
         self.set_name(name)
@@ -65,6 +67,10 @@ class AlbumButton(Gtk.Box):
     def update_artist(self, artist:str):
         self.artist_el.get_child().set_label(artist)
         self.artist_el.set_tooltip_text(artist)
+
+    def update_year(self, year:int):
+        if(year > 0):
+            self.subtitle.set_label(str(year))
 
     def update_artist_id(self, artistId:str):
         self.artist_el.set_action_target_value(GLib.Variant.new_string(artistId))

--- a/src/widgets/album/button.py
+++ b/src/widgets/album/button.py
@@ -13,12 +13,12 @@ class AlbumButton(Gtk.Box):
     star_el = Gtk.Template.Child()
     cover_button_el = Gtk.Template.Child()
     cover_el = Gtk.Template.Child()
+    name_button_el = Gtk.Template.Child()
     name_el = Gtk.Template.Child()
-    title_el = Gtk.Template.Child()
-    subtitle_el = Gtk.Template.Child()
+    year_el = Gtk.Template.Child()
     artist_el = Gtk.Template.Child()
 
-    def __init__(self, id:str):
+    def __init__(self, id:str, show_year:bool=False):
         self.id = id
         integration = get_current_integration()
         integration.verifyAlbum(self.id)
@@ -27,16 +27,19 @@ class AlbumButton(Gtk.Box):
         self.play_el.set_action_target_value(GLib.Variant.new_string(self.id))
         self.cover_button_el.set_action_target_value(GLib.Variant.new_string(self.id))
         self.star_el.set_action_target_value(GLib.Variant.new_string(self.id))
-        self.name_el.set_action_target_value(GLib.Variant.new_string(self.id))
+        self.name_button_el.set_action_target_value(GLib.Variant.new_string(self.id))
 
         self.settings = Gio.Settings(schema_id="com.jeffser.Nocturne")
         self.settings.connect("changed::button-size", lambda *_: GLib.idle_add(self.update_size))
+
+        self.show_year = show_year
 
         integration.connect_to_model(self.id, 'name', self.update_name)
         integration.connect_to_model(self.id, 'artist', self.update_artist)
         integration.connect_to_model(self.id, 'artistId', self.update_artist_id)
         integration.connect_to_model(self.id, 'gdkPaintable', self.update_cover)
         integration.connect_to_model(self.id, 'starred', self.update_starred)
+        integration.connect_to_model(self.id, 'year', self.update_year)
 
     def update_size(self):
         isBig = self.settings.get_value('button-size').unpack() == 'big'
@@ -45,11 +48,11 @@ class AlbumButton(Gtk.Box):
         self.cover_el.set_size_request(size, size)
         self.cover_el.set_pixel_size(pixel_size)
         if isBig:
-            self.title_el.remove_css_class('title-4')
-            self.title_el.add_css_class('title-3')
+            self.name_el.remove_css_class('title-4')
+            self.name_el.add_css_class('title-3')
         else:
-            self.title_el.remove_css_class('title-3')
-            self.title_el.add_css_class('title-4')
+            self.name_el.remove_css_class('title-3')
+            self.name_el.add_css_class('title-4')
 
     def update_cover(self, paintable:Gdk.Paintable=None):
         if paintable:
@@ -59,8 +62,8 @@ class AlbumButton(Gtk.Box):
         self.update_size()
 
     def update_name(self, name:str):
-        self.title_el.set_label(name)
-        self.name_el.set_tooltip_text(name)
+        self.name_el.set_label(name)
+        self.name_button_el.set_tooltip_text(name)
         self.cover_button_el.set_tooltip_text(name)
         self.set_name(name)
 
@@ -70,7 +73,11 @@ class AlbumButton(Gtk.Box):
 
     def update_year(self, year:int):
         if(year > 0):
-            self.subtitle.set_label(str(year))
+            if self.show_year:
+                self.year_el.set_label(str(year))
+                self.year_el.set_visible(True)
+        else:
+            self.year_el.set_visible(False)
 
     def update_artist_id(self, artistId:str):
         self.artist_el.set_action_target_value(GLib.Variant.new_string(artistId))
@@ -124,7 +131,7 @@ class AlbumButton(Gtk.Box):
             pointing_to=rect,
             has_arrow=False
         )
-        popover.set_parent(self.name_el)
+        popover.set_parent(self.name_button_el)
         popover.popup()
 
     @Gtk.Template.Callback()

--- a/src/widgets/artist/page.py
+++ b/src/widgets/artist/page.py
@@ -134,7 +134,7 @@ class ArtistPage(Adw.NavigationPage):
             albums = [a.get('id') for a in album_list if isinstance(a, dict)]
             album_buttons = []
             for album in albums:
-                button = AlbumButton(album)
+                button = AlbumButton(album, show_year=True)
                 button.artist_el.set_visible(False)
                 button.set_halign(Gtk.Align.CENTER)
                 button.name_el.remove_css_class('title-3')


### PR DESCRIPTION
This adds a release year to the album model and adds that release year to the name label for the album buttons on the artist pages. The sort order for the albums was a bit ambiguous before and it changed between Jellyfin (alphabetical) and Navidrome (chronological), the latter of which made it hard to tell what exactly it was being sorted by when the release year wasn't present. This brings Jellyfin in line with Navidrome to be sorted chronologically and clears up that sorting ambiguity. 

_Note: I added the release year to the album name button as a new label instead of the separate artist button because having the year be clickable didn't make sense, but having a random unclickable label looked odd._

<img width="1836" height="1546" alt="Screenshot From 2026-06-04 04-50-47" src="https://github.com/user-attachments/assets/15f3b2c0-e9ea-416b-af97-550fefc2b147" />

