### PR TITLE
fix: Fix fallback authentication not working for OpenSubsonic servers that return error code 42

### DIFF
--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -56,7 +56,7 @@ class Navidrome(Base):
             response = self.send_request(action, params)
             if response.status_code == 200:
                 data = response.json().get('subsonic-response', {})
-                if data.get('status') == 'failed' and data.get('error', {}).get('code') == 41:
+                if data.get('status') == 'failed' and data.get('error', {}).get('code') in (41, 42):
                     self._use_apikey_auth = True
                     response = self.send_request(action, params)
                     if response.status_code == 200:


### PR DESCRIPTION
Resolves #210

The current logic that determines wheter the OpenSubsonic server does not support token + salt authentication was only taking into account servers that respond with the OpenSubsonics error `41` (Like Nextcloud Music)

This PR adds error code `42` to the same fallback path, so that the newer apiKey authentication method is used for servers that return that error code.

https://opensubsonic.netlify.app/docs/responses/error/

| Error Code | Description |
| :--- | :--- |
| **41** | Token authentication not supported for LDAP users. |
| **42** | Provided authentication mechanism not supported. |