### PR TITLE
Favorites page changes to lazy loading, instant search, throttled art

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 gschemas.compiled
 nocturne.gresource
+.flatpak-builder

--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -3,7 +3,7 @@
 from gi.repository import GLib, GObject, Gdk
 from . import models, secret, sql_instance
 from ..constants import get_nocturne_version, DEFAULT_MUSIC_DIR, INTEGRATIONS_DIR
-import requests, urllib3, time, os, json
+import requests, urllib3, time, os, json, threading
 from datetime import datetime
 from requests.adapters import HTTPAdapter, Retry
 
@@ -21,6 +21,11 @@ class Base(GObject.Object):
 
     # Always have a currentSong inside loaded_models
     loaded_models = {'currentSong': models.CurrentSong()}
+
+    # Limits concurrent cover art fetches and texture decodes,
+    # Gdk.Texture.new_from_bytes spawns a sandboxed glycin loader process
+    # per decode on newer GTK, spawning hundreds at once can crash the app
+    cover_art_semaphore = threading.BoundedSemaphore(4)
 
     url = GObject.Property(type=str)
     trustServer = GObject.Property(type=bool, default=False)
@@ -135,6 +140,13 @@ class Base(GObject.Object):
         # Returns URL that can be used to get coverArt directly by external services
         # Returns empty string when a url is not available
         return ""
+
+    def requestCoverArt(self, model_id:str=''):
+        # Starts a background cover art fetch unless it's already cached,
+        # called by widgets when they actually need to display the cover
+        model = self.loaded_models.get(model_id)
+        if model and not model.get_property('gdkPaintable'):
+            threading.Thread(target=self.getCoverArt, args=(model_id,), daemon=True).start()
 
     def ping(self) -> dict:
         # return True if logged in and connection is successful

--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -155,36 +155,41 @@ class Jellyfin(Base):
             if not big and model.get_property('gdkPaintable') is not None:
                 return model.get_property('gdkPaintable')
 
-            params = {
-                'maxWidth': 720 if big else 240,
-                'quality': 90
-            }
-            try:
-                response = self.session.get(
-                    self.get_url('Items/{id}/Images/Primary', id=model_id),
-                    headers=self.get_base_header(),
-                    params=params,
-                    verify=not self.get_property('trustServer'),
-                    timeout=10
-                )
-                # Treat non-200 responses as empty content to avoid
-                # propagating network-related exceptions up and into the UI thread
-                response.raise_for_status()
-                response_bytes = response.content
-            except Exception as e:
-                response_bytes = b''
-                logger.error(f"can't get image from {model_id}: {e}")
-
-            if response_bytes and len(response_bytes) > 0:
-                try:
-                    gbytes = GLib.Bytes.new(response_bytes)
-                    texture = Gdk.Texture.new_from_bytes(gbytes)
-                    if big:
-                        return texture
-                    model.set_property('gdkPaintable', texture)
+            with self.cover_art_semaphore:
+                # Re-check, another thread might have loaded it while waiting
+                if not big and model.get_property('gdkPaintable') is not None:
                     return model.get_property('gdkPaintable')
+
+                params = {
+                    'maxWidth': 720 if big else 240,
+                    'quality': 90
+                }
+                try:
+                    response = self.session.get(
+                        self.get_url('Items/{id}/Images/Primary', id=model_id),
+                        headers=self.get_base_header(),
+                        params=params,
+                        verify=not self.get_property('trustServer'),
+                        timeout=10
+                    )
+                    # Treat non-200 responses as empty content to avoid
+                    # propagating network-related exceptions up and into the UI thread
+                    response.raise_for_status()
+                    response_bytes = response.content
                 except Exception as e:
-                    logger.error(f"can't convert image from {model_id}: {e}")
+                    response_bytes = b''
+                    logger.error(f"can't get image from {model_id}: {e}")
+
+                if response_bytes and len(response_bytes) > 0:
+                    try:
+                        gbytes = GLib.Bytes.new(response_bytes)
+                        texture = Gdk.Texture.new_from_bytes(gbytes)
+                        if big:
+                            return texture
+                        model.set_property('gdkPaintable', texture)
+                        return model.get_property('gdkPaintable')
+                    except Exception as e:
+                        logger.error(f"can't convert image from {model_id}: {e}")
         return None
 
     def getCoverArtUrl(self, model_id:str='', big:bool=False) -> str:
@@ -366,19 +371,21 @@ class Jellyfin(Base):
         return id_list
 
     def getStarredSongs(self) -> list:
-        song_list = []
+        # The list request already returns full metadata for every song,
+        # load it into the models so searching and displaying doesn't need
+        # per song requests
         songs = self.make_request(
             action="Users/{userId}/Items",
             mode="GET",
             params={
                 "IncludeItemTypes": "Audio",
                 "Recursive": "true",
-                "Fields": "Id",
+                "Fields": "ArtistItems,AlbumId,RunTimeTicks,UserData,IndexNumber,ParentIndexNumber",
                 "Filters": "IsFavorite"
             }
         ).get("Items", [])
 
-        return [song.get("Id") for song in songs]
+        return [song_id for song in songs if (song_id := self.load_song_dict(song))]
 
     def verifyArtist(self, model_id:str, force_update:bool=False, use_threading:bool=True):
         def run():
@@ -520,6 +527,33 @@ class Jellyfin(Base):
 
         threading.Thread(target=self.getCoverArt, args=(model_id,), daemon=True).start()
 
+    def load_song_dict(self, song:dict) -> str:
+        # Creates or updates a Song model from an API item dict, returns the model id
+        model_id = song.get("Id", "")
+        if not model_id:
+            return ''
+        data = dict(
+            id=model_id,
+            title=song.get("Name"),
+            album=song.get("Album"),
+            albumId=song.get("AlbumId"),
+            artist=song.get("AlbumArtist"),
+            artistId=(song.get("ArtistItems") or [{}])[0].get("Id"),
+            duration=int(song.get("RunTimeTicks", 0) / 10000000),
+            artists=[{"id": art.get("Id"), "name": art.get("Name")} for art in song.get("ArtistItems", [])],
+            starred=song.get("UserData", {}).get("IsFavorite", False),
+            track=song.get("IndexNumber") or 0,
+            discNumber=song.get("ParentIndexNumber") or 0,
+            albumGain=song.get("AlbumNormalizationGain", song.get("NormalizationGain")) or 0.0,
+            trackGain=song.get("NormalizationGain") or 0.0,
+            userRating=self.get_rating(model_id)
+        )
+        if model_id in self.loaded_models:
+            self.loaded_models.get(model_id).update_data(**data)
+        else:
+            self.loaded_models[model_id] = models.Song(**data)
+        return model_id
+
     def verifySong(self, model_id:str, force_update:bool=False, use_threading:bool=True):
         def run():
             params = {
@@ -533,23 +567,7 @@ class Jellyfin(Base):
             )
 
             if song.get("Id"):
-                duration = int(song.get("RunTimeTicks", 0) / 10000000)
-                self.loaded_models.get(model_id).update_data(
-                    id=song.get("Id"),
-                    title=song.get("Name"),
-                    album=song.get("Album"),
-                    albumId=song.get("AlbumId"),
-                    artist=song.get("AlbumArtist"),
-                    artistId=(song.get("ArtistItems") or [{}])[0].get("Id"),
-                    duration=duration,
-                    artists=[{"id": art.get("Id"), "name": art.get("Name")} for art in song.get("ArtistItems", [])],
-                    starred=song.get("UserData", {}).get("IsFavorite", False),
-                    track=song.get("IndexNumber") or 0,
-                    discNumber=song.get("ParentIndexNumber") or 0,
-                    albumGain=song.get("AlbumNormalizationGain", song.get("NormalizationGain")) or 0.0,
-                    trackGain=song.get("NormalizationGain") or 0.0,
-                    userRating=self.get_rating(model_id)
-                )
+                self.load_song_dict(song)
             elif model_id in self.loaded_models:
                 self.loaded_models.get(model_id).set_property('deleted', True)
                 del self.loaded_models[model_id]
@@ -561,8 +579,6 @@ class Jellyfin(Base):
                 threading.Thread(target=run, daemon=True).start()
             else:
                 run()
-
-        threading.Thread(target=self.getCoverArt, args=(model_id,), daemon=True).start()
 
     def star(self, model_id:str) -> bool:
         response = self.make_request(

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -145,29 +145,34 @@ class Local(Base):
             if not coverArtPath:
                 return None
 
-            tag = TinyTag.get(coverArtPath, image=True)
-            if tag is None:
-                return None
+            with self.cover_art_semaphore:
+                # Re-check, another thread might have loaded it while waiting
+                if not big and not isinstance(model, models.Playlist) and model.get_property('gdkPaintable'):
+                    return model.get_property('gdkPaintable')
 
-            image_data = tag.get_image()
-            if not image_data:
-                return None
+                tag = TinyTag.get(coverArtPath, image=True)
+                if tag is None:
+                    return None
 
-            try:
-                img = Image.open(io.BytesIO(image_data))
-                width = 720 if big else 240
-                w_percent = (width / float(img.size[0]))
-                height = int((float(img.size[1]) * float(w_percent)))
-                resized_img = img.resize((width, height), Image.LANCZOS)
-                buffer = io.BytesIO()
-                resized_img.save(buffer, format="JPEG", quality=85)
-                raw_data = buffer.getvalue()
-                gbytes = GLib.Bytes.new(raw_data)
-                texture = Gdk.Texture.new_from_bytes(gbytes)
-                model.set_property('gdkPaintable', texture)
-                return model.get_property('gdkPaintable')
-            except Exception as e:
-                logger.error(f"can't get image from {model_id}: {e}")
+                image_data = tag.get_image()
+                if not image_data:
+                    return None
+
+                try:
+                    img = Image.open(io.BytesIO(image_data))
+                    width = 720 if big else 240
+                    w_percent = (width / float(img.size[0]))
+                    height = int((float(img.size[1]) * float(w_percent)))
+                    resized_img = img.resize((width, height), Image.LANCZOS)
+                    buffer = io.BytesIO()
+                    resized_img.save(buffer, format="JPEG", quality=85)
+                    raw_data = buffer.getvalue()
+                    gbytes = GLib.Bytes.new(raw_data)
+                    texture = Gdk.Texture.new_from_bytes(gbytes)
+                    model.set_property('gdkPaintable', texture)
+                    return model.get_property('gdkPaintable')
+                except Exception as e:
+                    logger.error(f"can't get image from {model_id}: {e}")
         return None
 
     def getCoverArtUrl(self, model_id:str="", big:bool=False) -> str:
@@ -313,8 +318,6 @@ class Local(Base):
             for artist in song.get('artists', []):
                 if artist.get('id'):
                     update_artist(artist.get('id'), artist.get('name'))
-
-            self.getCoverArt(model_id)
 
         # safe check before loading
         song = self.loaded_models.get(model_id)

--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -95,28 +95,33 @@ class Navidrome(Base):
             if not big and model.get_property('gdkPaintable'):
                 return model.get_property('gdkPaintable')
 
-            params = {
-                **self.get_base_params(),
-                'id': model.get_property('coverArt') or model.get_property('id'),
-                'size': 720 if big else 240
-            }
-            response = self.session.get(
-                self.get_url('getCoverArt'),
-                params=params,
-                verify=not self.get_property('trustServer')
-            )
-            response_bytes = response.content if response.status_code == 200 else b''
-
-            if response_bytes and len(response_bytes) > 0:
-                try:
-                    gbytes = GLib.Bytes.new(response_bytes)
-                    texture = Gdk.Texture.new_from_bytes(gbytes)
-                    if big:
-                        return texture
-                    model.set_property('gdkPaintable', texture)
+            with self.cover_art_semaphore:
+                # Re-check, another thread might have loaded it while waiting
+                if not big and model.get_property('gdkPaintable'):
                     return model.get_property('gdkPaintable')
-                except Exception as e:
-                    logger.error(f"can't convert image from {model_id}: {e}")
+
+                params = {
+                    **self.get_base_params(),
+                    'id': model.get_property('coverArt') or model.get_property('id'),
+                    'size': 720 if big else 240
+                }
+                response = self.session.get(
+                    self.get_url('getCoverArt'),
+                    params=params,
+                    verify=not self.get_property('trustServer')
+                )
+                response_bytes = response.content if response.status_code == 200 else b''
+
+                if response_bytes and len(response_bytes) > 0:
+                    try:
+                        gbytes = GLib.Bytes.new(response_bytes)
+                        texture = Gdk.Texture.new_from_bytes(gbytes)
+                        if big:
+                            return texture
+                        model.set_property('gdkPaintable', texture)
+                        return model.get_property('gdkPaintable')
+                    except Exception as e:
+                        logger.error(f"can't convert image from {model_id}: {e}")
         return None
 
     def getCoverArtUrl(self, model_id:str='', big:bool=False) -> str:
@@ -204,8 +209,10 @@ class Navidrome(Base):
         return playlist_ids
 
     def getStarredSongs(self) -> list:
+        # getStarred2 already returns full song metadata, load it into the
+        # models so searching and displaying doesn't need per song requests
         songs = self.make_request('getStarred2').get('starred2', {}).get('song', [])
-        return [song.get('id') for song in songs]
+        return [song_id for song in songs if (song_id := self.load_song_dict(song))]
 
     def verifyArtist(self, model_id:str, force_update:bool=False, use_threading:bool=True):
         def update():
@@ -275,19 +282,30 @@ class Navidrome(Base):
 
         threading.Thread(target=self.getCoverArt, args=(model_id,), daemon=True).start()
 
+    def load_song_dict(self, song_dict:dict) -> str:
+        # Creates or updates a Song model from an API song dict, returns the model id
+        model_id = str(song_dict.get('id', ''))
+        if not model_id:
+            return ''
+        song_dict['id'] = model_id
+        if 'artists' not in song_dict and song_dict.get('artistId'):
+            song_dict['artists'] = [{
+                'id': song_dict.get('artistId'),
+                'name': song_dict.get('artist')
+            }]
+        gains = song_dict.get('replayGain') or {}
+        if model_id in self.loaded_models:
+            self.loaded_models.get(model_id).update_data(**song_dict, albumGain=gains.get('albumGain', 0.0), trackGain=gains.get('trackGain', 0.0))
+        else:
+            self.loaded_models[model_id] = models.Song(**song_dict, albumGain=gains.get('albumGain', 0.0), trackGain=gains.get('trackGain', 0.0))
+        return model_id
+
     def verifySong(self, model_id:str, force_update:bool=False, use_threading:bool=True):
         def update():
             response = self.make_request('getSong', {'id': model_id})
             song_dict = response.get('song', {})
             if song_dict.get('id'):
-                if 'artists' not in song_dict and song_dict.get('artistId'):
-                    song_dict['artists'] = [{
-                        'id': song_dict.get('artistId'),
-                        'name': song_dict.get('artist')
-                    }]
-                gains = song_dict.get('replayGain') or {}
-                self.loaded_models.get(model_id).update_data(**song_dict, albumGain=gains.get('albumGain', 0.0), trackGain=gains.get('trackGain', 0.0))
-                threading.Thread(target=self.getCoverArt, args=(model_id,), daemon=True).start()
+                self.load_song_dict(song_dict)
             elif model_id in self.loaded_models:
                 self.loaded_models.get(model_id).set_property('deleted', True)
                 del self.loaded_models[model_id]
@@ -301,8 +319,6 @@ class Navidrome(Base):
                 threading.Thread(target=update, daemon=True).start()
             else:
                 update()
-        else:
-            threading.Thread(target=self.getCoverArt, args=(model_id,), daemon=True).start()
 
     def star(self, model_id:str) -> bool:
         response = self.make_request('star', {'id': model_id})

--- a/src/ui/pages/songs_starred.blp
+++ b/src/ui/pages/songs_starred.blp
@@ -22,7 +22,7 @@ template $NocturneSongsStarredPage: Adw.NavigationPage {
         }
       }
 
-      title-widget: Gtk.SearchEntry {
+      title-widget: Gtk.SearchEntry search_entry {
         hexpand: true;
         key-capture-widget: main_stack;
         placeholder-text: _("Favorite Songs");
@@ -41,9 +41,10 @@ template $NocturneSongsStarredPage: Adw.NavigationPage {
       }
       Gtk.StackPage {
         name: "content";
-        child: Gtk.ScrolledWindow {
+        child: Gtk.ScrolledWindow scrolledwindow {
           propagate-natural-width: true;
           propagate-natural-height: true;
+          edge-reached => $scroll_edge_reached();
 
           child: Adw.Clamp {
             maximum-size: 2000;
@@ -81,6 +82,26 @@ template $NocturneSongsStarredPage: Adw.NavigationPage {
                     styles [
                       "m10"
                     ]
+                  };
+                }
+              }
+
+              Gtk.Stack end_stack {
+                Gtk.StackPage {
+                  name: "loading";
+                  child: Adw.Spinner {};
+                }
+                Gtk.StackPage {
+                  name: "end";
+                  child: Gtk.Label {
+                    styles [
+                      "dimmed"
+                    ]
+                    label: _("Reached End of List");
+                    halign: center;
+                    wrap: true;
+                    wrap-mode: word_char;
+                    justify: center;
                   };
                 }
               }

--- a/src/widgets/pages/songs_starred.py
+++ b/src/widgets/pages/songs_starred.py
@@ -3,25 +3,38 @@
 from gi.repository import Gtk, Adw, GLib
 from ...integrations import get_current_integration
 from ..song import SongRow, SongButton
+import threading
 import re
 
 @Gtk.Template(resource_path='/com/jeffser/Nocturne/pages/songs_starred.ui')
 class SongsStarredPage(Adw.NavigationPage):
     __gtype_name__ = 'NocturneSongsStarredPage'
 
+    search_entry = Gtk.Template.Child()
     list_el = Gtk.Template.Child()
     wrapbox_el = Gtk.Template.Child()
     main_stack = Gtk.Template.Child()
+    end_stack = Gtk.Template.Child()
+    scrolledwindow = Gtk.Template.Child()
+    offset = 0
+    loading = False
+    generation = 0
+    song_ids = []
+    filtered_ids = []
+
+    def __init__(self):
+        super().__init__()
+        self.scrolledwindow.get_vadjustment().connect('notify::upper', lambda va, ud: GLib.timeout_add(1000, self.check_scrollbar, va))
+
+    def check_scrollbar(self, adjustment):
+        if adjustment.get_upper() <= adjustment.get_page_size() and self.end_stack.get_visible_child_name() == 'loading':
+            threading.Thread(target=self.load_songs, daemon=True).start()
 
     def reload(self):
         GLib.idle_add(self.main_stack.set_visible_child_name, 'loading')
         integration = get_current_integration()
-        songs = integration.getStarredSongs()
-        GLib.idle_add(self.reset)
-        for id in songs:
-            GLib.idle_add(self.list_el.list_el.append, SongRow(id))
-            GLib.idle_add(self.wrapbox_el.append, SongButton(id))
-        GLib.idle_add(self.update_visibility)
+        self.song_ids = integration.getStarredSongs()
+        GLib.idle_add(self.apply_search)
 
     def reset(self):
         self.list_el.list_el.remove_all()
@@ -30,10 +43,54 @@ class SongsStarredPage(Adw.NavigationPage):
 
     @Gtk.Template.Callback()
     def on_search(self, search_entry):
-        query = search_entry.get_text()
-        for child in list(self.list_el.list_el) + list(self.wrapbox_el):
-            child.set_visible(child.get_name() != 'GtkListBoxRow' and re.search(query, child.get_name(), re.IGNORECASE))
-        GLib.idle_add(self.update_visibility)
+        self.apply_search()
+
+    def apply_search(self):
+        # Filters by title using the metadata loaded by getStarredSongs,
+        # widgets are only created for songs that match
+        query = self.search_entry.get_text()
+        pattern = None
+        if query:
+            try:
+                pattern = re.compile(query, re.IGNORECASE)
+            except re.error:
+                pattern = re.compile(re.escape(query), re.IGNORECASE)
+        integration = get_current_integration()
+        filtered = []
+        for song_id in self.song_ids:
+            if model := integration.loaded_models.get(song_id):
+                if not pattern or pattern.search(model.get_property('title') or ''):
+                    filtered.append(song_id)
+
+        self.generation += 1
+        self.filtered_ids = filtered
+        self.offset = 0
+        self.reset()
+        self.end_stack.set_visible_child_name('loading')
+        threading.Thread(target=self.load_songs, daemon=True).start()
+
+    def load_songs(self, count=30):
+        if self.loading:
+            return
+        self.loading = True
+        generation = self.generation
+        chunk = [(SongRow(song_id), SongButton(song_id)) for song_id in self.filtered_ids[self.offset:self.offset + count]]
+
+        def add_chunk():
+            if generation == self.generation:
+                for row, button in chunk:
+                    self.list_el.list_el.append(row)
+                    self.wrapbox_el.append(button)
+                self.offset += len(chunk)
+                self.end_stack.set_visible_child_name('end' if self.offset >= len(self.filtered_ids) else 'loading')
+                self.update_visibility()
+            self.loading = False
+        GLib.idle_add(add_chunk)
+
+    @Gtk.Template.Callback()
+    def scroll_edge_reached(self, scrolledwindow, pos):
+        if pos == Gtk.PositionType.BOTTOM and self.end_stack.get_visible_child_name() == 'loading':
+            threading.Thread(target=self.load_songs, daemon=True).start()
 
     def update_visibility(self):
         for row in list(self.list_el.list_el):
@@ -41,4 +98,3 @@ class SongsStarredPage(Adw.NavigationPage):
                 self.main_stack.set_visible_child_name('content')
                 return
         self.main_stack.set_visible_child_name('no-content')
-        

--- a/src/widgets/song/button.py
+++ b/src/widgets/song/button.py
@@ -30,6 +30,15 @@ class SongButton(Gtk.Box):
         integration.connect_to_model(self.id, 'gdkPaintable', self.update_cover)
         integration.connect_to_model('currentSong', 'songId', self.current_song_changed)
 
+        # Only fetch cover art once the widget is actually shown,
+        # 'title' re-triggers in case metadata wasn't loaded yet at map time
+        self.connect('map', self.request_cover)
+        integration.connect_to_model(self.id, 'title', self.request_cover)
+
+    def request_cover(self, *_):
+        if self.get_mapped():
+            get_current_integration().requestCoverArt(self.id)
+
     def update_size(self):
         isBig = self.settings.get_value('button-size').unpack() == 'big'
         size = 240 if isBig else 180

--- a/src/widgets/song/small_row.py
+++ b/src/widgets/song/small_row.py
@@ -27,6 +27,15 @@ class SongSmallRow(Gtk.Button):
         integration.connect_to_model(self.id, 'gdkPaintable', self.update_cover)
         integration.connect_to_model(self.id, 'deleted', self.delete_status_changed)
 
+        # Only fetch cover art once the widget is actually shown,
+        # 'title' re-triggers in case metadata wasn't loaded yet at map time
+        self.connect('map', self.request_cover)
+        integration.connect_to_model(self.id, 'title', self.request_cover)
+
+    def request_cover(self, *_):
+        if self.get_mapped():
+            get_current_integration().requestCoverArt(self.id)
+
     def delete_status_changed(self, status:bool):
         if status:
             if wrapbox := self.get_ancestor(Adw.WrapBox):


### PR DESCRIPTION
This PR is work done before the latest commits to address favorites loading, searching, and glycin thumnail loading app crashes.

The difference with my code is the searching is now done on a list of pre-loaded favorites, which leads to the entire search being able to complete on a list of 3000 songs in about 1 second (vs searching and displaying widgets while batching the loading).

I have also removed the requirement to load thumbnails while loading the songs so that thumbnails and the background thread aren't processing them when the list is loading and the thumbnails aren't displayed (like in the favorites list). This comes with significant performance improvement.

There is an additional semaphore added for thumbnail processing so that the loading does not crash the app from too many glycin loader spawns.

