### PR TITLE
docs: add Debian installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ Nocturne is packaged unofficially in the AUR, to install it first make sure you 
 ```sh
 yay -S nocturne
 ```
-
+### Debian
+Nocturne is packaged unofficially in the official Debian archive (Available in Debian 14 'forky' and above). Install it via apt.
+```sh
+apt install nocturne
+```
 ### NixOS/nix
 Nocturne is packaged unofficially in nixpkgs.
 You can either try it out using nix-shell:


### PR DESCRIPTION
I have packaged nocturne into the official debian archive and it can be installed now using apt in Debian 14 or above.

I've added the installation instructions in this commit.