### PR TITLE
Fix file permissions and desktop entry type for Nocturne Search Provider

### DIFF
--- a/data/com.jeffser.Nocturne.SearchProvider.desktop.in
+++ b/data/com.jeffser.Nocturne.SearchProvider.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Type=Service
+Type=Application
 Name=Nocturne Search Provider
 Icon=com.jeffser.Nocturne
 DBusActivatable=true

--- a/src/meson.build
+++ b/src/meson.build
@@ -105,7 +105,7 @@ configure_file(
   configuration: conf,
   install: true,
   install_dir: get_option('bindir'),
-  install_mode: 'r-xr-xr-x'
+  install_mode: 'rwxr-xr-x'
 )
 
 nocturne_sources = [


### PR DESCRIPTION
Hi,

I encountered some errors and warnings while building the debian package for v1.3.1.

The first one is with incorrect file permissions that caused build failures. I changed the permissions in this PR which got rid of the errors.

The second issue (warning) is with the Search provider desktop file. Apparently the Type=Service is not a recognised type so I replaced it with Application instead which fixed the warning.

More info about the warning here: [https://lintian.debian.org/tags/desktop-entry-unknown-type.html](https://lintian.debian.org/tags/desktop-entry-unknown-type.html)