### PR TITLE
Added Brazilian Portuguese (pt_BR) localization

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -8,3 +8,4 @@ te
 tr
 zh_CN
 zh_TW
+pt_BR

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -6,7 +6,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Nocturne\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-07-21 03:36-0300\n"
 "PO-Revision-Date: 2026-07-21 10:50-0300\n"
@@ -21,391 +21,393 @@ msgstr ""
 #: data/com.jeffser.Nocturne.desktop.in:2
 #: data/com.jeffser.Nocturne.metainfo.xml.in:7
 msgid "Nocturne"
-msgstr ""
+msgstr "Nocturne"
 
 #: data/com.jeffser.Nocturne.desktop.in:10
 msgid "GTK;Navidrome;Jellyfin;Music;"
-msgstr ""
+msgstr "GTK;Navidrome;Jellyfin;Música;"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:8
 msgid "Bring your music library together"
-msgstr ""
+msgstr "Reúna toda a sua biblioteca de músicas"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:10
 msgid "A modern music client"
-msgstr ""
+msgstr "Um cliente de música moderno"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:11
 msgid "Features"
-msgstr ""
+msgstr "Recursos"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:13
 msgid "Compatibility with Jellyfin, OpenSubsonic, Bandcamp and local files"
-msgstr ""
+msgstr "Compatível com Jellyfin, OpenSubsonic, Bandcamp e arquivos locais"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:14
 msgid "Exploration by songs, artists, albums, radios and playlists"
-msgstr ""
+msgstr "Explore músicas, artistas, álbuns, rádios e playlists"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:15
 msgid "Playlist management"
-msgstr ""
+msgstr "Gerenciamento de playlists"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:16
 msgid "Audio equalizer and audio visualizer"
-msgstr ""
+msgstr "Equalizador e visualizador de áudio"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:17
 msgid "Mpris integration"
-msgstr ""
+msgstr "Integração com MPRIS"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:18
 msgid "Integrated Navidrome instance management"
-msgstr ""
+msgstr "Gerenciamento integrado de instâncias do Navidrome"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:19
 msgid "Automatic lyrics fetching"
-msgstr ""
+msgstr "Obtenção automática de letras"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:20
 msgid "Downloads and offline mode"
-msgstr ""
+msgstr "Downloads e modo offline"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:21
 msgid "Cool interface"
-msgstr ""
+msgstr "Interface moderna"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:26
 msgid "Jeffry Samuel Eduarte Rojas"
-msgstr ""
+msgstr "Jeffry Samuel Eduarte Rojas"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:66
 msgid "Main homepage"
-msgstr ""
+msgstr "Página inicial"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:70
 msgid "Song queue"
-msgstr ""
+msgstr "Fila de reprodução"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:74
 #: src/ui/playing/popout_window.blp:93 src/ui/window.blp:182
 #: src/ui/window.blp:234
 msgid "Lyrics"
-msgstr ""
+msgstr "Letras"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:78
 msgid "Song list"
-msgstr ""
+msgstr "Lista de músicas"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:82
 msgid "Album page"
-msgstr ""
+msgstr "Página do álbum"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:86
 msgid "Mini Player"
-msgstr ""
+msgstr "Mini player"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:91
 msgid "opensubsonic"
-msgstr ""
+msgstr "opensubsonic"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:92
 msgid "bandcamp"
-msgstr ""
+msgstr "bandcamp"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:93
 msgid "navidrome"
-msgstr ""
+msgstr "navidrome"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:94
 msgid "jellyfin"
-msgstr ""
+msgstr "jellyfin"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:95
 msgid "music"
-msgstr ""
+msgstr "música"
 
 #: data/com.jeffser.Nocturne.metainfo.xml.in:96
 msgid "gtk"
-msgstr ""
+msgstr "gtk"
 
 #: data/com.jeffser.Nocturne.SearchProvider.desktop.in:3
 msgid "Nocturne Search Provider"
-msgstr ""
+msgstr "Provedor de pesquisa do Nocturne"
 
 #: src/actions.py:140 src/widgets/pages/login.py:117
 msgid "Error"
-msgstr ""
+msgstr "Erro"
 
 #: src/actions.py:141
 msgid "No details provided"
-msgstr ""
+msgstr "Nenhum detalhe fornecido"
 
 #: src/actions.py:143 src/actions.py:284 src/preferences.py:486
 #: src/ui/song/queue.blp:40
 msgid "Close"
-msgstr ""
+msgstr "Fechar"
 
 #: src/actions.py:181
 #, python-brace-format
 msgid "Not enough data found for Nocturne Playback ({})"
-msgstr ""
+msgstr "Dados insuficientes para o Nocturne Playback ({})"
 
 #: src/actions.py:281 src/ui/song/row.blp:72
 msgid "External File"
-msgstr ""
+msgstr "Arquivo externo"
 
 #: src/actions.py:282
 msgid ""
 "This track was loaded from an external file, this means it will have less "
 "features compared to a track inside the library"
 msgstr ""
+"Esta faixa foi carregada de um arquivo externo, portanto terá menos recursos "
+"do que uma faixa da biblioteca."
 
 #: src/actions.py:302
 msgid "Navidrome server deleted successfully"
-msgstr ""
+msgstr "Servidor do Navidrome removido com sucesso"
 
 #: src/actions.py:311
 msgid "Delete Navidrome Server"
-msgstr ""
+msgstr "Remover servidor do Navidrome"
 
 #: src/actions.py:312
 msgid "Are you sure you want to delete the integrated Navidrome server?"
-msgstr ""
+msgstr "Tem certeza de que deseja remover o servidor integrado do Navidrome?"
 
 #: src/actions.py:314 src/actions.py:453 src/actions.py:487 src/actions.py:687
 #: src/actions.py:765 src/preferences.py:431 src/ui/lyrics/dialog.blp:16
 #: src/ui/lyrics/dialog.blp:17 src/widgets/pages/login.py:162
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: src/actions.py:315
 msgid "Keep Data"
-msgstr ""
+msgstr "Manter dados"
 
 #: src/actions.py:316
 msgid "Delete Everything"
-msgstr ""
+msgstr "Excluir tudo"
 
 #: src/actions.py:401
 msgid "No Name"
-msgstr ""
+msgstr "Sem nome"
 
 #: src/actions.py:420
 msgid "Radio updated successfully"
-msgstr ""
+msgstr "Rádio atualizada com sucesso"
 
 #: src/actions.py:420
 msgid "Radio added successfully"
-msgstr ""
+msgstr "Rádio adicionada com sucesso"
 
 #: src/actions.py:427
 msgid "Error updating radio"
-msgstr ""
+msgstr "Erro ao atualizar a rádio"
 
 #: src/actions.py:427
 msgid "Error adding radio"
-msgstr ""
+msgstr "Erro ao adicionar a rádio"
 
 #: src/actions.py:438 src/actions.py:679
 msgid "Name"
-msgstr ""
+msgstr "Nome"
 
 #: src/actions.py:443
 msgid "Stream Url"
-msgstr ""
+msgstr "URL do stream"
 
 #: src/actions.py:450
 msgid "Update Radio Station"
-msgstr ""
+msgstr "Atualizar estação de rádio"
 
 #: src/actions.py:450
 msgid "Add Radio Station"
-msgstr ""
+msgstr "Adicionar estação de rádio"
 
 #: src/actions.py:454 src/preferences.py:432 src/ui/lyrics/dialog.blp:23
 #: src/ui/lyrics/dialog.blp:24
 msgid "Save"
-msgstr ""
+msgstr "Salvar"
 
 #: src/actions.py:467
 msgid "Radio deleted successfully"
-msgstr ""
+msgstr "Rádio removida com sucesso"
 
 #: src/actions.py:471
 msgid "Error deleting radio"
-msgstr ""
+msgstr "Erro ao remover a rádio"
 
 #: src/actions.py:484
 msgid "Delete Radio Station"
-msgstr ""
+msgstr "Remover estação de rádio"
 
 #: src/actions.py:485 src/actions.py:763
 #, python-brace-format
 msgid "Are you sure you want to delete '{}'?"
-msgstr ""
+msgstr "Tem certeza de que deseja remover '{}'?"
 
 #: src/actions.py:488 src/actions.py:766 src/constants.py:533
 #: src/constants.py:581
 msgid "Delete"
-msgstr ""
+msgstr "Excluir"
 
 #: src/actions.py:507 src/actions.py:519 src/actions.py:521 src/actions.py:585
 #: src/actions.py:636
 msgid "Playing Next"
-msgstr ""
+msgstr "Reproduzindo em seguida"
 
 #: src/actions.py:511 src/actions.py:526 src/actions.py:528 src/actions.py:592
 #: src/actions.py:643
 msgid "Playing Later"
-msgstr ""
+msgstr "Reproduzir mais tarde"
 
 #: src/actions.py:519 src/actions.py:526 src/actions.py:876 src/actions.py:1001
 #: src/widgets/playlist/dialog.py:31
 #, python-brace-format
 msgid "{} Songs"
-msgstr ""
+msgstr "{} músicas"
 
 #: src/actions.py:553
 msgid "Lyrics Saved"
-msgstr ""
+msgstr "Letra salva"
 
 #: src/actions.py:661
 msgid "Playlist updated successfully"
-msgstr ""
+msgstr "Playlist atualizada com sucesso"
 
 #: src/actions.py:661
 msgid "Playlist created successfully"
-msgstr ""
+msgstr "Playlist criada com sucesso"
 
 #: src/actions.py:663
 msgid "Error updating playlist"
-msgstr ""
+msgstr "Erro ao atualizar a playlist"
 
 #: src/actions.py:663
 msgid "Error creating playlist"
-msgstr ""
+msgstr "Erro ao criar a playlist"
 
 #: src/actions.py:684
 msgid "Update Playlist"
-msgstr ""
+msgstr "Atualizar playlist"
 
 #: src/actions.py:684 src/ui/pages/playlists.blp:41
 msgid "Create Playlist"
-msgstr ""
+msgstr "Criar playlist"
 
 #: src/actions.py:688
 msgid "Update"
-msgstr ""
+msgstr "Atualizar"
 
 #: src/actions.py:688
 msgid "Create"
-msgstr ""
+msgstr "Criar"
 
 #: src/actions.py:701
 #, python-brace-format
 msgid "{} Song Removed"
 msgid_plural "{} Songs Removed"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{} música removida"
+msgstr[1] "{} músicas removidas"
 
 #: src/actions.py:726 src/actions.py:740
 #, python-brace-format
 msgid "{} Song Added"
 msgid_plural "{} Songs Added"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{} música adicionada"
+msgstr[1] "{} músicas adicionadas"
 
 #: src/actions.py:744 src/actions.py:881
 #, python-brace-format
 msgid "{} Song Skipped"
 msgid_plural "{} Songs Skipped"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{} música ignorada"
+msgstr[1] "{} músicas ignoradas"
 
 #: src/actions.py:755
 msgid "Playlist Deleted"
-msgstr ""
+msgstr "Playlist removida"
 
 #: src/actions.py:762
 msgid "Delete Playlist"
-msgstr ""
+msgstr "Remover playlist"
 
 #: src/actions.py:812
 msgid "No songs found"
-msgstr ""
+msgstr "Nenhuma música encontrada"
 
 #: src/actions.py:853 src/actions.py:877 src/actions.py:912 src/actions.py:945
 msgid "Download Started"
-msgstr ""
+msgstr "Download iniciado"
 
 #: src/actions.py:860 src/actions.py:888 src/actions.py:895 src/actions.py:928
 #: src/actions.py:961
 msgid "Already Downloaded"
-msgstr ""
+msgstr "Já baixado"
 
 #: src/actions.py:882
 #, python-brace-format
 msgid "{} Song ({})"
 msgid_plural "{} Songs ({})"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{} música ({})"
+msgstr[1] "{} músicas ({})"
 
 #: src/actions.py:894
 msgid "Download Skipped"
-msgstr ""
+msgstr "Download ignorado"
 
 #: src/actions.py:916 src/actions.py:949
 #, python-brace-format
 msgid "Download Started ({} Song Skipped)"
 msgid_plural "Download Started ({} Songs Skipped)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Download iniciado ({} música ignorada)"
+msgstr[1] "Download iniciado ({} músicas ignoradas)"
 
 #: src/actions.py:985 src/actions.py:1002
 msgid "Deleted"
-msgstr ""
+msgstr "Removido"
 
 #: src/constants.py:343 src/ui/playing/playback_mode_button.blp:5
 msgid "Consecutive"
-msgstr ""
+msgstr "Sequencial"
 
 #: src/constants.py:347
 msgid "Repeat All"
-msgstr ""
+msgstr "Repetir todas"
 
 #: src/constants.py:351
 msgid "Repeat One"
-msgstr ""
+msgstr "Repetir uma"
 
 #: src/constants.py:356
 #, python-brace-format
 msgid "Low ({})"
-msgstr ""
+msgstr "Baixa ({})"
 
 #: src/constants.py:357
 #, python-brace-format
 msgid "Medium ({})"
-msgstr ""
+msgstr "Média ({})"
 
 #: src/constants.py:358
 #, python-brace-format
 msgid "High ({})"
-msgstr ""
+msgstr "Alta ({})"
 
 #: src/constants.py:359
 #, python-brace-format
 msgid "Ultra ({})"
-msgstr ""
+msgstr "Ultra ({})"
 
 #: src/constants.py:360
 msgid "Original File"
-msgstr ""
+msgstr "Arquivo original"
 
 #. Item
 #: src/constants.py:367 src/ui/pages/home.blp:5
 msgid "Home"
-msgstr ""
+msgstr "Início"
 
 #. Item
 #. list
@@ -413,45 +415,45 @@ msgstr ""
 #: src/ui/pages/artists.blp:5 src/ui/pages/artists.blp:28
 #: src/ui/preferences.blp:286 src/widgets/pages/home.py:54
 msgid "Artists"
-msgstr ""
+msgstr "Artistas"
 
 #. Section
 #: src/constants.py:379 src/ui/pages/albums_all.blp:5
 #: src/ui/pages/albums_all.blp:28 src/ui/preferences.blp:278
 #: src/widgets/artist/page.py:53 src/widgets/pages/home.py:49
 msgid "Albums"
-msgstr ""
+msgstr "Álbuns"
 
 #. Item
 #: src/constants.py:382 src/constants.py:417 src/constants.py:437
 #: src/window.py:155
 msgid "All"
-msgstr ""
+msgstr "Todos"
 
 #. Item
 #: src/constants.py:387
 msgid "Random"
-msgstr ""
+msgstr "Aleatório"
 
 #. Item
 #: src/constants.py:392 src/constants.py:422
 msgid "Favorites"
-msgstr ""
+msgstr "Favoritos"
 
 #. Item
 #: src/constants.py:397
 msgid "Recently Added"
-msgstr ""
+msgstr "Adicionados recentemente"
 
 #. Item
 #: src/constants.py:402
 msgid "Recently Played"
-msgstr ""
+msgstr "Reproduzidos recentemente"
 
 #. Item
 #: src/constants.py:407
 msgid "Most Played"
-msgstr ""
+msgstr "Mais reproduzidos"
 
 #. Section
 #: src/constants.py:414 src/ui/pages/songs_all.blp:5
@@ -459,421 +461,425 @@ msgstr ""
 #: src/widgets/album/page.py:45 src/widgets/pages/home.py:38
 #: src/widgets/playlist/page.py:29
 msgid "Songs"
-msgstr ""
+msgstr "Músicas"
 
 #. Item
 #: src/constants.py:427 src/ui/pages/radios.blp:5 src/ui/pages/radios.blp:13
 msgid "Radios"
-msgstr ""
+msgstr "Rádios"
 
 #. Section
 #: src/constants.py:434 src/ui/pages/playlists.blp:5
 #: src/ui/pages/playlists.blp:28 src/ui/preferences.blp:294
 #: src/widgets/pages/home.py:59
 msgid "Playlists"
-msgstr ""
+msgstr "Playlists"
 
 #: src/constants.py:447 src/constants.py:498 src/ui/lyrics/dialog.blp:47
 #: src/ui/playing/control_page.blp:172 src/ui/playing/footer.blp:114
 #: src/ui/song/queue.blp:55 src/ui/song/queue.blp:57
 msgid "Play"
-msgstr ""
+msgstr "Reproduzir"
 
 #: src/constants.py:452 src/constants.py:485 src/constants.py:508
 msgid "Shuffle"
-msgstr ""
+msgstr "Embaralhar"
 
 #: src/constants.py:457 src/constants.py:513 src/constants.py:546
 #: src/ui/song/queue.blp:63 src/ui/song/queue.blp:65
 msgid "Play Next"
-msgstr ""
+msgstr "Reproduzir em seguida"
 
 #: src/constants.py:462 src/constants.py:518 src/constants.py:551
 #: src/ui/song/queue.blp:71 src/ui/song/queue.blp:73
 msgid "Play Later"
-msgstr ""
+msgstr "Reproduzir mais tarde"
 
 #: src/constants.py:467 src/constants.py:561 src/ui/song/queue.blp:79
 #: src/ui/song/queue.blp:81
 msgid "Add To Playlist"
-msgstr ""
+msgstr "Adicionar à playlist"
 
 #: src/constants.py:472 src/constants.py:523 src/constants.py:566
 #: src/ui/pages/setup.blp:23 src/ui/playing/lyrics_page.blp:167
 #: src/ui/playing/lyrics_page.blp:170 src/ui/song/queue.blp:87
 #: src/ui/song/queue.blp:89
 msgid "Download"
-msgstr ""
+msgstr "Baixar"
 
 #: src/constants.py:477 src/constants.py:576
 #: src/nocturne_search_provider.py.in:11 src/ui/playing/control_page.blp:83
 msgid "Show Artist"
-msgstr ""
+msgstr "Mostrar artista"
 
 #: src/constants.py:490 src/ui/playing/lyrics_page.blp:146
 #: src/widgets/song/row.py:109
 msgid "Radio"
-msgstr ""
+msgstr "Rádio"
 
 #: src/constants.py:503
 msgid "Resume"
-msgstr ""
+msgstr "Retomar"
 
 #: src/constants.py:528 src/constants.py:556
 msgid "Edit"
-msgstr ""
+msgstr "Editar"
 
 #: src/constants.py:542
 msgid "Select"
-msgstr ""
+msgstr "Selecionar"
 
 #: src/constants.py:571 src/ui/album/button.blp:49
 #: src/ui/playing/control_page.blp:98
 msgid "Show Album"
-msgstr ""
+msgstr "Mostrar álbum"
 
 #: src/constants.py:587 src/ui/song/queue.blp:98 src/ui/song/queue.blp:100
 msgid "Remove"
-msgstr ""
+msgstr "Remover"
 
 #: src/constants.py:592 src/ui/song/queue.blp:109 src/ui/song/queue.blp:111
 msgid "Delete Download"
-msgstr ""
+msgstr "Excluir download"
 
 #: src/constants.py:598 src/main.py:156
 msgid "Show Details"
-msgstr ""
+msgstr "Mostrar detalhes"
 
 #: src/constants.py:609
 msgid "Visit Webpage"
-msgstr ""
+msgstr "Visitar página"
 
 #: src/constants.py:615
 msgid "Update Server"
-msgstr ""
+msgstr "Atualizar servidor"
 
 #: src/constants.py:620
 msgid "Delete Server"
-msgstr ""
+msgstr "Remover servidor"
 
 #: src/constants.py:629
 msgid "Edit Lyrics"
-msgstr ""
+msgstr "Editar letra"
 
 #: src/constants.py:634
 msgid "Remove Lyrics"
-msgstr ""
+msgstr "Remover letra"
 
 #: src/integrations/base.py:296
 msgid "Could not generate SQL database"
-msgstr ""
+msgstr "Não foi possível gerar o banco de dados SQL"
 
 #: src/integrations/discord_rpc.py:171
 msgid "Browsing"
-msgstr ""
+msgstr "Navegando"
 
 #: src/integrations/discord_rpc.py:189
 msgid "Listening to music"
-msgstr ""
+msgstr "Ouvindo música"
 
 #: src/integrations/jellyfin.py:18
 msgid "Connect to a Jellyfin server."
-msgstr ""
+msgstr "Conecte-se a um servidor Jellyfin."
 
 #: src/integrations/jellyfin.py:22
 msgid "Jellyfin"
-msgstr ""
+msgstr "Jellyfin"
 
 #: src/integrations/jellyfin.py:23
 msgid "Use an existing Jellyfin instance"
-msgstr ""
+msgstr "Use uma instância Jellyfin existente"
 
 #: src/integrations/jellyfin.py:258
 msgid "Could not log in"
-msgstr ""
+msgstr "Não foi possível fazer login"
 
 #: src/integrations/jellyfin.py:1041
 msgid "Unknown"
-msgstr ""
+msgstr "Desconhecido"
 
 #: src/integrations/local.py:20 src/integrations/local.py:26
 #: src/integrations/local.py:668
 msgid "Local Files"
-msgstr ""
+msgstr "Arquivos locais"
 
 #: src/integrations/local.py:21
 msgid ""
 "Let Nocturne load your local files directly, for big libraries it is "
 "recommended to use a dedicated server."
 msgstr ""
+"Permita que o Nocturne carregue seus arquivos locais diretamente. Para "
+"bibliotecas grandes, é recomendado usar um servidor dedicado."
 
 #: src/integrations/local.py:23 src/ui/pages/setup.blp:67
 #: src/ui/pages/setup.blp:68
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
 #: src/integrations/local.py:27
 msgid "Limited functionality"
-msgstr ""
+msgstr "Funcionalidade limitada"
 
 #. load songs, albums, artists
 #: src/integrations/local.py:68
 msgid "Loading Songs"
-msgstr ""
+msgstr "Carregando músicas"
 
 #: src/integrations/local.py:138 src/integrations/navidrome.py:760
 msgid "Could not locate path, try again"
-msgstr ""
+msgstr "Não foi possível localizar o caminho, tente novamente"
 
 #: src/integrations/local.py:317
 msgid "No Album"
-msgstr ""
+msgstr "Sem álbum"
 
 #: src/integrations/local.py:686 src/integrations/local.py:695
 msgid "Offline Mode"
-msgstr ""
+msgstr "Modo offline"
 
 #: src/integrations/local.py:687
 msgid "Access your downloads"
-msgstr ""
+msgstr "Acesse seus downloads"
 
 #: src/integrations/models.py:142 src/ui/album/page.blp:5
 #: src/widgets/album/page.py:129
 msgid "Album"
-msgstr ""
+msgstr "Álbum"
 
 #: src/integrations/models.py:144
 msgid "Display Artist"
-msgstr ""
+msgstr "Exibir artista"
 
 #: src/integrations/models.py:146
 msgid "MusicBrainz ID"
-msgstr ""
+msgstr "ID do MusicBrainz"
 
 #: src/integrations/models.py:147
 msgid "Track Number"
-msgstr ""
+msgstr "Número da faixa"
 
 #: src/integrations/models.py:148
 msgid "Year"
-msgstr ""
+msgstr "Ano"
 
 #: src/integrations/models.py:149
 msgid "Size"
-msgstr ""
+msgstr "Tamanho"
 
 #: src/integrations/models.py:150
 msgid "Suffix"
-msgstr ""
+msgstr "Extensão"
 
 #: src/integrations/models.py:151 src/widgets/album/button.py:90
 #: src/widgets/album/page.py:145 src/widgets/artist/page.py:125
 #: src/widgets/playing/control_page.py:189 src/widgets/song/row.py:183
 msgid "Favorite"
-msgstr ""
+msgstr "Favorito"
 
 #: src/integrations/models.py:152
 msgid "Duration"
-msgstr ""
+msgstr "Duração"
 
 #: src/integrations/models.py:154
 msgid "Bit Rate"
-msgstr ""
+msgstr "Taxa de bits"
 
 #: src/integrations/models.py:155
 msgid "Bit Depth"
-msgstr ""
+msgstr "Profundidade de bits"
 
 #: src/integrations/models.py:156
 msgid "Sampling Rate"
-msgstr ""
+msgstr "Taxa de amostragem"
 
 #: src/integrations/models.py:157
 msgid "Channel Count"
-msgstr ""
+msgstr "Quantidade de canais"
 
 #: src/integrations/models.py:159
 msgid "Path"
-msgstr ""
+msgstr "Caminho"
 
 #: src/integrations/models.py:160
 msgid "Disc Number"
-msgstr ""
+msgstr "Número do disco"
 
 #: src/integrations/models.py:161
 msgid "BPM"
-msgstr ""
+msgstr "BPM"
 
 #: src/integrations/models.py:162
 msgid "Genres"
-msgstr ""
+msgstr "Gêneros"
 
 #. list
 #: src/integrations/models.py:164
 msgid "Track Gain"
-msgstr ""
+msgstr "Ganho da faixa"
 
 #: src/integrations/models.py:165
 msgid "Album Gain"
-msgstr ""
+msgstr "Ganho do álbum"
 
 #: src/integrations/navidrome.py:19
 msgid "Connect to an OpenSubsonic server like Navidrome."
-msgstr ""
+msgstr "Conecte-se a um servidor OpenSubsonic como o Navidrome."
 
 #: src/integrations/navidrome.py:23
 msgid "External Server"
-msgstr ""
+msgstr "Servidor externo"
 
 #: src/integrations/navidrome.py:24
 msgid "Use an existing OpenSubsonic instance"
-msgstr ""
+msgstr "Use uma instância OpenSubsonic existente"
 
 #: src/integrations/navidrome.py:172
 msgid "Server returned an error"
-msgstr ""
+msgstr "O servidor retornou um erro"
 
 #: src/integrations/navidrome.py:172
 msgid "Unknown Error"
-msgstr ""
+msgstr "Erro desconhecido"
 
 #: src/integrations/navidrome.py:735 src/integrations/navidrome.py:744
 msgid "Managed Server"
-msgstr ""
+msgstr "Servidor gerenciado"
 
 #: src/integrations/navidrome.py:736
 msgid "Connect to a Navidrome instance directly managed by Nocturne."
-msgstr ""
+msgstr "Conecte-se a uma instância do Navidrome gerenciada diretamente pelo Nocturne."
 
 #: src/integrations/navidrome.py:739
 msgid "Manage Server"
-msgstr ""
+msgstr "Gerenciar servidor"
 
 #: src/integrations/navidrome.py:745
 msgid "Create and use a Navidrome instance"
-msgstr ""
+msgstr "Crie e use uma instância do Navidrome"
 
 #: src/integrations/navidrome.py:804
 msgid "Important: Use your Subsonic login information."
-msgstr ""
+msgstr "Importante: use suas informações de login do Subsonic."
 
 #: src/integrations/navidrome.py:807
 msgid "Bandcamp User Settings"
-msgstr ""
+msgstr "Configurações de usuário do Bandcamp"
 
 #: src/integrations/navidrome.py:813
 msgid "Explore your online library"
-msgstr ""
+msgstr "Explore sua biblioteca online"
 
 #: src/main.py:94
 msgid "Music is Playing"
-msgstr ""
+msgstr "Música em reprodução"
 
 #: src/main.py:107
 msgid "Fullscreen Player Active"
-msgstr ""
+msgstr "Reprodutor em tela cheia ativo"
 
 #: src/main.py:153
 msgid "Login Failed"
-msgstr ""
+msgstr "Falha no login"
 
 #: src/nocturne_search_provider.py.in:12 src/ui/album/button.blp:21
 msgid "Play Album"
-msgstr ""
+msgstr "Reproduzir álbum"
 
 #: src/nocturne_search_provider.py.in:13 src/ui/song/button.blp:16
 msgid "Play Song"
-msgstr ""
+msgstr "Reproduzir música"
 
 #: src/nocturne_search_provider.py.in:14 src/ui/playlist/button.blp:28
 msgid "Play Playlist"
-msgstr ""
+msgstr "Reproduzir playlist"
 
 #: src/nocturne_search_provider.py.in:113
 msgid "Open"
-msgstr ""
+msgstr "Abrir"
 
 #: src/preferences.py:420
 msgid "Settings Page"
-msgstr ""
+msgstr "Página de configurações"
 
 #: src/preferences.py:423
 msgid "User Token"
-msgstr ""
+msgstr "Token de usuário"
 
 #: src/preferences.py:427
 msgid "Link ListenBrainz"
-msgstr ""
+msgstr "Vincular ListenBrainz"
 
 #: src/preferences.py:428
 msgid "Connect your ListenBrainz account with a user token"
-msgstr ""
+msgstr "Conecte sua conta do ListenBrainz usando um token de usuário"
 
 #: src/preferences.py:476
 msgid "Flatpak Sandbox Warning"
-msgstr ""
+msgstr "Aviso da sandbox do Flatpak"
 
 #: src/preferences.py:477
 msgid ""
 "To connect to Discord, an additional permission is required, once you run "
 "the following command, please restart Nocturne"
 msgstr ""
+"Para conectar-se ao Discord, é necessária uma permissão adicional. Após "
+"executar o comando a seguir, reinicie o Nocturne"
 
 #: src/ui/album/button.blp:36 src/ui/album/page.blp:152
 #: src/ui/artist/page.blp:150 src/ui/song/row.blp:115
 msgid "Toggle star"
-msgstr ""
+msgstr "Alternar estrela"
 
 #: src/ui/album/button.blp:61 src/ui/album/page.blp:50 src/ui/album/row.blp:32
 msgid "Album cover art"
-msgstr ""
+msgstr "Capa do álbum"
 
 #: src/ui/album/button.blp:87
 msgid "Enter album page"
-msgstr ""
+msgstr "Entrar na página do álbum"
 
 #: src/ui/album/button.blp:128 src/ui/album/page.blp:85
 #: src/ui/song/button.blp:81
 msgid "Enter artist page"
-msgstr ""
+msgstr "Entrar na página do artista"
 
 #: src/ui/album/page.blp:95 src/ui/artist/page.blp:93
 #: src/ui/playing/control_page.blp:228 src/widgets/containers/context.py:50
 msgid "1 Star"
-msgstr ""
+msgstr "1 estrela"
 
 #: src/ui/album/page.blp:104 src/ui/artist/page.blp:102
 #: src/ui/playing/control_page.blp:237
 msgid "2 Stars"
-msgstr ""
+msgstr "2 estrelas"
 
 #: src/ui/album/page.blp:113 src/ui/artist/page.blp:111
 #: src/ui/playing/control_page.blp:246
 msgid "3 Stars"
-msgstr ""
+msgstr "3 estrelas"
 
 #: src/ui/album/page.blp:122 src/ui/artist/page.blp:120
 #: src/ui/playing/control_page.blp:255
 msgid "4 Stars"
-msgstr ""
+msgstr "4 estrelas"
 
 #: src/ui/album/page.blp:131 src/ui/artist/page.blp:129
 #: src/ui/playing/control_page.blp:264
 msgid "5 Stars"
-msgstr ""
+msgstr "5 estrelas"
 
 #: src/ui/album/row.blp:48 src/ui/artist/row.blp:40 src/ui/playlist/row.blp:48
 #: src/ui/song/row.blp:130
 msgid "Options"
-msgstr ""
+msgstr "Opções"
 
 #: src/ui/artist/page.blp:5
 msgid "Artist"
-msgstr ""
+msgstr "Artista"
 
 #: src/ui/artist/page.blp:83
 msgid "Expand Biography"
-msgstr ""
+msgstr "Expandir biografia"
 
 #: src/ui/containers/carousel.blp:24 src/ui/containers/carousel.blp:26
 #: src/ui/containers/wrapbox.blp:19 src/ui/containers/wrapbox.blp:21
@@ -882,1034 +888,1043 @@ msgstr ""
 #: src/ui/pages/songs_starred.blp:15 src/ui/song/queue.blp:16
 #: src/ui/song/queue.blp:18
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 #: src/ui/containers/carousel.blp:41
 msgid "Pan to the Left"
-msgstr ""
+msgstr "Deslocar para a esquerda"
 
 #: src/ui/containers/carousel.blp:47
 msgid "Pan to the Right"
-msgstr ""
+msgstr "Deslocar para a direita"
 
 #: src/ui/containers/download_row.blp:31
 msgid "Downloaded"
-msgstr ""
+msgstr "Baixado"
 
 #: src/ui/containers/download_row.blp:52
 msgid "Remove From Queue"
-msgstr ""
+msgstr "Remover da fila"
 
 #: src/ui/containers/downloads_queue_button.blp:10
 msgid "Downloads Queue"
-msgstr ""
+msgstr "Fila de downloads"
 
 #: src/ui/containers/downloads_queue_button.blp:11
 msgid "Downloaded songs are available in offline mode"
-msgstr ""
+msgstr "As músicas baixadas estão disponíveis no modo offline"
 
 #: src/ui/containers/downloads_queue_button.blp:19
 msgid "Clear Done Downloads"
-msgstr ""
+msgstr "Limpar downloads concluídos"
 
 #: src/ui/lyrics/dialog.blp:5
 msgid "Lyrics Editor"
-msgstr ""
+msgstr "Editor de letras"
 
 #: src/ui/lyrics/dialog.blp:61 src/ui/playing/control_page.blp:187
 #: src/ui/playing/footer.blp:129
 msgid "Pause"
-msgstr ""
+msgstr "Pausar"
 
 #: src/ui/lyrics/dialog.blp:98 src/ui/playing/control_page.blp:122
 msgid "Current song progress bar"
-msgstr ""
+msgstr "Barra de progresso da música atual"
 
 #: src/ui/lyrics/dialog.blp:103
 msgid "Set Next Line Timestamp to Now"
-msgstr ""
+msgstr "Definir o tempo da próxima linha para agora"
 
 #: src/ui/lyrics/dialog.blp:112
 msgid "Add Line at Timestamp"
-msgstr ""
+msgstr "Adicionar linha no tempo"
 
 #: src/ui/lyrics/dialog.blp:133
 msgid "No Lyrics"
-msgstr ""
+msgstr "Sem letras"
 
 #: src/ui/lyrics/dialog.blp:134
 msgid "No lyrics found for this track, to get started add a new line"
-msgstr ""
+msgstr "Nenhuma letra encontrada para esta faixa. Para começar, adicione uma nova linha"
 
 #: src/ui/lyrics/edit_row.blp:9
 msgid "Timestamp"
-msgstr ""
+msgstr "Marca de tempo"
 
 #: src/ui/lyrics/edit_row.blp:15 src/ui/lyrics/edit_row.blp:17
 msgid "Go to Timestamp"
-msgstr ""
+msgstr "Ir para a marca de tempo"
 
 #: src/ui/lyrics/edit_row.blp:27 src/ui/lyrics/edit_row.blp:29
 msgid "Set Current Timestamp"
-msgstr ""
+msgstr "Definir marca de tempo atual"
 
 #: src/ui/lyrics/edit_row.blp:39 src/ui/lyrics/edit_row.blp:41
 msgid "Remove Line"
-msgstr ""
+msgstr "Remover linha"
 
 #: src/ui/pages/albums_all.blp:20 src/ui/pages/artists.blp:20
 #: src/ui/pages/playlists.blp:20 src/ui/pages/songs_all.blp:20
 #: src/ui/pages/songs_starred.blp:20
 msgid "Grid"
-msgstr ""
+msgstr "Grade"
 
 #: src/ui/pages/albums_all.blp:31
 msgid "Search albums"
-msgstr ""
+msgstr "Pesquisar álbuns"
 
 #: src/ui/pages/albums_all.blp:99 src/ui/pages/albums.blp:53
 #: src/ui/pages/artists.blp:98 src/ui/pages/playlists.blp:111
 #: src/ui/pages/songs_all.blp:100
 msgid "Reached End of List"
-msgstr ""
+msgstr "Fim da lista alcançado"
 
 #: src/ui/pages/albums_all.blp:115 src/ui/pages/albums.blp:69
 msgid "No Albums Found"
-msgstr ""
+msgstr "Nenhum álbum encontrado"
 
 #: src/ui/pages/artists.blp:31
 msgid "Search artists"
-msgstr ""
+msgstr "Pesquisar artistas"
 
 #: src/ui/pages/artists.blp:114
 msgid "No Artists Found"
-msgstr ""
+msgstr "Nenhum artista encontrado"
 
 #: src/ui/pages/home.blp:15
 msgid "Toggle Search"
-msgstr ""
+msgstr "Alternar pesquisa"
 
 #: src/ui/pages/home.blp:24 src/ui/shortcuts-dialog.blp:8
 msgid "Search"
-msgstr ""
+msgstr "Pesquisar"
 
 #: src/ui/pages/home.blp:68
 msgid "No Elements Found"
-msgstr ""
+msgstr "Nenhum elemento encontrado"
 
 #. Login Button
 #: src/ui/pages/login.blp:5 src/ui/pages/login.blp:16
 #: src/ui/pages/login.blp:107 src/ui/pages/login.blp:108
 #: src/widgets/pages/login.py:38 src/widgets/pages/login.py:78
 msgid "Login"
-msgstr ""
+msgstr "Entrar"
 
 #: src/ui/pages/login.blp:36
 msgid "Server Status"
-msgstr ""
+msgstr "Status do servidor"
 
 #: src/ui/pages/login.blp:37 src/widgets/pages/login.py:52
 msgid "Not Running"
-msgstr ""
+msgstr "Não está em execução"
 
 #: src/ui/pages/login.blp:38
 msgid "Restart Instance"
-msgstr ""
+msgstr "Reiniciar instância"
 
 #: src/ui/pages/login.blp:50
 msgid "Manage Navidrome Server"
-msgstr ""
+msgstr "Gerenciar servidor Navidrome"
 
 #: src/ui/pages/login.blp:60
 msgid "Url"
-msgstr ""
+msgstr "URL"
 
 #: src/ui/pages/login.blp:67
 msgid "More Options"
-msgstr ""
+msgstr "Mais opções"
 
 #: src/ui/pages/login.blp:73
 msgid "Trust Server Certificates"
-msgstr ""
+msgstr "Confiar nos certificados do servidor"
 
 #: src/ui/pages/login.blp:81
 msgid "Library Directory"
-msgstr ""
+msgstr "Diretório da biblioteca"
 
 #: src/ui/pages/login.blp:93
 msgid "Username"
-msgstr ""
+msgstr "Nome de usuário"
 
 #: src/ui/pages/login.blp:97
 msgid "Password"
-msgstr ""
+msgstr "Senha"
 
 #: src/ui/pages/login.blp:117 src/ui/pages/login.blp:118
 msgid "Use Quick Connect"
-msgstr ""
+msgstr "Usar conexão rápida"
 
 #: src/ui/pages/playback.blp:5 src/ui/shortcuts-dialog.blp:25
 msgid "Playback"
-msgstr ""
+msgstr "Reprodução"
 
 #: src/ui/pages/playback.blp:17
 msgid "Go Home"
-msgstr ""
+msgstr "Ir para início"
 
 #: src/ui/pages/playback.blp:24
 msgid "Toggle Visualizer"
-msgstr ""
+msgstr "Alternar visualizador"
 
 #: src/ui/pages/playback.blp:54 src/window.py:213
 msgid "Nocturne Playback"
-msgstr ""
+msgstr "Reprodução do Nocturne"
 
 #: src/ui/pages/playback.blp:64
 msgid "These are your most played songs from last month"
-msgstr ""
+msgstr "Estas são suas músicas mais reproduzidas no último mês"
 
 #: src/ui/pages/playback.blp:83 src/ui/pages/playback.blp:85
 msgid "Save Playlist"
-msgstr ""
+msgstr "Salvar playlist"
 
 #: src/ui/pages/playback.blp:98 src/ui/pages/playback.blp:100
 msgid "Playlist Added"
-msgstr ""
+msgstr "Playlist adicionada"
 
 #: src/ui/pages/playback.blp:123
 msgid "Thank you for using Nocturne!"
-msgstr ""
+msgstr "Obrigado por usar o Nocturne!"
 
 #: src/ui/pages/playlists.blp:31
 msgid "Search playlists"
-msgstr ""
+msgstr "Pesquisar playlists"
 
 #: src/ui/pages/playlists.blp:127
 msgid "No Playlists Found"
-msgstr ""
+msgstr "Nenhuma playlist encontrada"
 
 #: src/ui/pages/radios.blp:16
 msgid "Search radios"
-msgstr ""
+msgstr "Pesquisar rádios"
 
 #: src/ui/pages/radios.blp:26
 msgid "Add Radio"
-msgstr ""
+msgstr "Adicionar rádio"
 
 #: src/ui/pages/radios.blp:61
 msgid "No Radios Found"
-msgstr ""
+msgstr "Nenhuma rádio encontrada"
 
 #: src/ui/pages/setup.blp:5
 msgid "Setup"
-msgstr ""
+msgstr "Configuração"
 
 #: src/ui/pages/setup.blp:19
 msgid "Navidrome Download"
-msgstr ""
+msgstr "Download do Navidrome"
 
 #: src/ui/pages/setup.blp:20
 msgid "Nocturne will download Navidrome automatically"
-msgstr ""
+msgstr "O Nocturne baixará o Navidrome automaticamente"
 
 #: src/ui/pages/setup.blp:22
 msgid "Download (~20 mb)"
-msgstr ""
+msgstr "Baixar (~20 MB)"
 
 #: src/ui/pages/setup.blp:34
 msgid "Downloading"
-msgstr ""
+msgstr "Baixando"
 
 #: src/ui/pages/setup.blp:46
 msgid "An Error Occurred"
-msgstr ""
+msgstr "Ocorreu um erro"
 
 #: src/ui/pages/setup.blp:47
 msgid "Please try again later"
-msgstr ""
+msgstr "Tente novamente mais tarde"
 
 #: src/ui/pages/setup.blp:55
 msgid "Download Successful"
-msgstr ""
+msgstr "Download concluído com sucesso"
 
 #: src/ui/pages/setup.blp:56
 msgid ""
 "Before continuing make sure you create an admin account and also make sure "
 "all your tracks are inside your music directory"
 msgstr ""
+"Antes de continuar, certifique-se de criar uma conta de administrador e "
+"também de que todas as suas faixas estejam dentro do diretório de músicas"
 
 #: src/ui/pages/setup.blp:63
 msgid "Instance Webpage"
-msgstr ""
+msgstr "Página web da instância"
 
 #: src/ui/pages/songs_all.blp:31
 msgid "Search songs"
-msgstr ""
+msgstr "Pesquisar músicas"
 
 #: src/ui/pages/songs_all.blp:116 src/ui/pages/songs_starred.blp:96
 #: src/ui/song/queue.blp:137
 msgid "No Songs Found"
-msgstr ""
+msgstr "Nenhuma música encontrada"
 
 #: src/ui/pages/songs_starred.blp:5 src/ui/pages/songs_starred.blp:28
 msgid "Favorite Songs"
-msgstr ""
+msgstr "Músicas favoritas"
 
 #: src/ui/pages/songs_starred.blp:31
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Pesquisar músicas favoritas"
 
 #: src/ui/pages/welcome.blp:5
 msgid "Welcome"
-msgstr ""
+msgstr "Boas-vindas"
 
 #: src/ui/pages/welcome.blp:16
 msgid "Welcome to Nocturne"
-msgstr ""
+msgstr "Boas-vindas ao Nocturne"
 
 #: src/ui/pages/welcome.blp:17
 msgid "Select an instance type to get started"
-msgstr ""
+msgstr "Selecione um tipo de instância para começar"
 
 #: src/ui/playing/control_page.blp:5
 msgid "Playing"
-msgstr ""
+msgstr "Reproduzindo"
 
 #: src/ui/playing/control_page.blp:75
 msgid "Visit current radio homepage"
-msgstr ""
+msgstr "Visitar página inicial da rádio atual"
 
 #: src/ui/playing/control_page.blp:157 src/ui/playing/footer.blp:99
 msgid "Previous"
-msgstr ""
+msgstr "Anterior"
 
 #: src/ui/playing/control_page.blp:201 src/ui/playing/footer.blp:143
 msgid "Next"
-msgstr ""
+msgstr "Próxima"
 
 #: src/ui/playing/control_page.blp:221
 msgid "Rate"
-msgstr ""
+msgstr "Avaliar"
 
 #: src/ui/playing/control_page.blp:277
 msgid "Star"
-msgstr ""
+msgstr "Estrela"
 
 #: src/ui/playing/control_page.blp:284
 msgid "Toggle Sidebar"
-msgstr ""
+msgstr "Alternar barra lateral"
 
 #: src/ui/playing/cover_art.blp:35
 msgid "Audio"
-msgstr ""
+msgstr "Áudio"
 
 #: src/ui/playing/cover_art.blp:43 src/ui/song/details_dialog.blp:34
 msgid "Song Cover"
-msgstr ""
+msgstr "Capa da música"
 
 #: src/ui/playing/cover_art.blp:49 src/ui/playing/cover_art.blp:57
 msgid "Video"
-msgstr ""
+msgstr "Vídeo"
 
 #: src/ui/playing/equalizer_page.blp:21
 msgid "Presets"
-msgstr ""
+msgstr "Predefinições"
 
 #: src/ui/playing/equalizer_page.blp:26
 msgid "Flat"
-msgstr ""
+msgstr "Plano"
 
 #: src/ui/playing/equalizer_page.blp:33
 msgid "Vocal Clarity"
-msgstr ""
+msgstr "Clareza vocal"
 
 #: src/ui/playing/equalizer_page.blp:38
 msgid "Smooth Jazz"
-msgstr ""
+msgstr "Jazz suave"
 
 #: src/ui/playing/equalizer_page.blp:43
 msgid "Rock"
-msgstr ""
+msgstr "Rock"
 
 #: src/ui/playing/equalizer_page.blp:48
 msgid "Classic"
-msgstr ""
+msgstr "Clássico"
 
 #: src/ui/playing/equalizer_page.blp:53
 msgid "Acoustic"
-msgstr ""
+msgstr "Acústico"
 
 #: src/ui/playing/footer.blp:12
 msgid "Current song progress indicator"
-msgstr ""
+msgstr "Indicador de progresso da música atual"
 
 #: src/ui/playing/footer.blp:45
 msgid "Current song cover art"
-msgstr ""
+msgstr "Capa da música atual"
 
 #: src/ui/playing/lyrics_page.blp:25 src/ui/playing/lyrics_page.blp:85
 #: src/ui/playing/lyrics_page.blp:115 src/ui/playing/lyrics_page.blp:119
 #: src/ui/playing/lyrics_page.blp:132 src/ui/playing/lyrics_page.blp:136
 msgid "Go Back"
-msgstr ""
+msgstr "Voltar"
 
 #: src/ui/playing/lyrics_page.blp:67
 msgid "Lyrics Options"
-msgstr ""
+msgstr "Opções de letras"
 
 #: src/ui/playing/lyrics_page.blp:112
 msgid "No Lyrics Found"
-msgstr ""
+msgstr "Nenhuma letra encontrada"
 
 #: src/ui/playing/lyrics_page.blp:129
 msgid "Instrumental"
-msgstr ""
+msgstr "Instrumental"
 
 #: src/ui/playing/lyrics_page.blp:154
 msgid "Not Downloaded"
-msgstr ""
+msgstr "Não baixado"
 
 #: src/ui/playing/lyrics_page.blp:156
 msgid ""
 "The lyrics for this song have not been downloaded yet, they might be "
 "available for download"
 msgstr ""
+"A letra desta música ainda não foi baixada, ela pode estar disponível "
+"para download"
 
 #: src/ui/playing/lyrics_page.blp:180 src/ui/playing/lyrics_page.blp:183
 msgid "Load Lyrics File"
-msgstr ""
+msgstr "Carregar arquivo de letra"
 
 #: src/ui/playing/popout_window.blp:5
 msgid "Pop-out Window"
-msgstr ""
+msgstr "Janela destacada"
 
 #: src/ui/playing/popout_window.blp:67 src/ui/song/details_dialog.blp:5
 #: src/ui/window.blp:206
 msgid "Song Details"
-msgstr ""
+msgstr "Detalhes da música"
 
 #: src/ui/playing/popout_window.blp:87 src/ui/window.blp:172
 #: src/ui/window.blp:228
 msgid "Queue"
-msgstr ""
+msgstr "Fila"
 
 #: src/ui/playing/popout_window.blp:99 src/ui/window.blp:188
 #: src/ui/window.blp:240
 msgid "Equalizer"
-msgstr ""
+msgstr "Equalizador"
 
 #: src/ui/playing/queue_page.blp:20
 msgid "Generating Next Queue"
-msgstr ""
+msgstr "Gerando próxima fila"
 
 #: src/ui/playing/queue_page.blp:24
 msgid "Autoplay"
-msgstr ""
+msgstr "Reprodução automática"
 
 #: src/ui/playing/queue_page.blp:25
 msgid "Generate a new queue when the current one ends"
-msgstr ""
+msgstr "Gerar uma nova fila quando a atual terminar"
 
 #: src/ui/playing/volume_button.blp:5
 msgid "Volume"
-msgstr ""
+msgstr "Volume"
 
 #: src/ui/playing/volume_button.blp:12
 msgid "Speaker Mute"
-msgstr ""
+msgstr "Alto-falante sem som"
 
 #: src/ui/playing/volume_button.blp:30
 msgid "Speaker Full Volume"
-msgstr ""
+msgstr "Alto-falante no volume máximo"
 
 #: src/ui/playlist/button.blp:41
 msgid "Show Playlist"
-msgstr ""
+msgstr "Mostrar playlist"
 
 #: src/ui/playlist/button.blp:53 src/ui/playlist/page.blp:50
 #: src/ui/playlist/row.blp:32 src/ui/playlist/selector_row.blp:24
 msgid "Playlist cover art"
-msgstr ""
+msgstr "Capa da playlist"
 
 #: src/ui/playlist/button.blp:65
 msgid "Enter playlist page"
-msgstr ""
+msgstr "Entrar na página da playlist"
 
 #: src/ui/playlist/dialog.blp:6 src/ui/playlist/page.blp:5
 #: src/widgets/playlist/page.py:84
 msgid "Playlist"
-msgstr ""
+msgstr "Playlist"
 
 #: src/ui/playlist/dialog.blp:11
 msgid "Search (or create new playlist)"
-msgstr ""
+msgstr "Pesquisar (ou criar nova playlist)"
 
 #: src/ui/playlist/dialog.blp:20
 msgid "Adding Music to Playlist"
-msgstr ""
+msgstr "Adicionando música à playlist"
 
 #: src/ui/playlist/dialog.blp:34
 msgid "Create New Playlist and Add Songs"
-msgstr ""
+msgstr "Criar nova playlist e adicionar músicas"
 
 #: src/ui/preferences.blp:7 src/ui/shortcuts-dialog.blp:6
 msgid "General"
-msgstr ""
+msgstr "Geral"
 
 #: src/ui/preferences.blp:10
 msgid "Behavior"
-msgstr ""
+msgstr "Comportamento"
 
 #: src/ui/preferences.blp:12
 msgid "Restore Queue on Launch"
-msgstr ""
+msgstr "Restaurar fila ao iniciar"
 
 #: src/ui/preferences.blp:15
 msgid "Hide on Close"
-msgstr ""
+msgstr "Ocultar ao fechar"
 
 #: src/ui/preferences.blp:18
 msgid "Simulate Word by Word Lyrics"
-msgstr ""
+msgstr "Simular letras palavra por palavra"
 
 #: src/ui/preferences.blp:19
 msgid "Used when only line by line lyrics are available"
-msgstr ""
+msgstr "Usado quando apenas letras linha por linha estão disponíveis"
 
 #: src/ui/preferences.blp:22
 msgid "Auto Download Lyrics"
-msgstr ""
+msgstr "Baixar letras automaticamente"
 
 #: src/ui/preferences.blp:23
 msgid "Used when the current instance does not provide lyrics"
-msgstr ""
+msgstr "Usado quando a instância atual não fornece letras"
 
 #: src/ui/preferences.blp:26
 msgid "Use Track and Album Gain"
-msgstr ""
+msgstr "Usar ganho da faixa e do álbum"
 
 #: src/ui/preferences.blp:27
 msgid "Adjust the volume based on gain metadata"
-msgstr ""
+msgstr "Ajustar o volume com base nos metadados de ganho"
 
 #: src/ui/preferences.blp:30
 msgid "Default Page on Login"
-msgstr ""
+msgstr "Página padrão ao entrar"
 
 #: src/ui/preferences.blp:35
 msgid "Maximum Bitrate"
-msgstr ""
+msgstr "Taxa de bits máxima"
 
 #: src/ui/preferences.blp:41
 msgid "Gnome Search"
-msgstr ""
+msgstr "Pesquisa do GNOME"
 
 #: src/ui/preferences.blp:42
 msgid ""
 "Search for your music directly from the system search bar while Nocturne is "
 "running. You can enable or disable this feature completely in System Settings"
 msgstr ""
+"Pesquise suas músicas diretamente pela barra de pesquisa do sistema enquanto "
+"o Nocturne estiver em execução. Você pode ativar ou desativar completamente "
+"esse recurso nas Configurações do Sistema"
 
 #: src/ui/preferences.blp:45
 msgid "Include Artists"
-msgstr ""
+msgstr "Incluir artistas"
 
 #: src/ui/preferences.blp:48
 msgid "Include Albums"
-msgstr ""
+msgstr "Incluir álbuns"
 
 #: src/ui/preferences.blp:51
 msgid "Include Songs"
-msgstr ""
+msgstr "Incluir músicas"
 
 #: src/ui/preferences.blp:54
 msgid "Include Playlists"
-msgstr ""
+msgstr "Incluir playlists"
 
 #: src/ui/preferences.blp:58
 msgid "Session"
-msgstr ""
+msgstr "Sessão"
 
 #: src/ui/preferences.blp:61
 msgid "Discord Rich Presence"
-msgstr ""
+msgstr "Rich Presence do Discord"
 
 #: src/ui/preferences.blp:62
 msgid "Share the currently playing song on Discord"
-msgstr ""
+msgstr "Compartilhar a música atual no Discord"
 
 #: src/ui/preferences.blp:66
 msgid "Share Cover Art With Discord"
-msgstr ""
+msgstr "Compartilhar capa com o Discord"
 
 #: src/ui/preferences.blp:67
 msgid ""
 "If the instance is not reachable by Discord servers, CoverArtArchive will be "
 "used instead"
 msgstr ""
+"Se a instância não puder ser acessada pelos servidores do Discord, o "
+"CoverArtArchive será usado em seu lugar"
 
 #: src/ui/preferences.blp:73
 msgid "ListenBrainz Link"
-msgstr ""
+msgstr "Link do ListenBrainz"
 
 #: src/ui/preferences.blp:74
 msgid "Keep track of your playback history"
-msgstr ""
+msgstr "Mantenha um registro do seu histórico de reprodução"
 
 #: src/ui/preferences.blp:80 src/ui/preferences.blp:81
 msgid "Link"
-msgstr ""
+msgstr "Vincular"
 
 #: src/ui/preferences.blp:89 src/ui/preferences.blp:90
 msgid "Unlink"
-msgstr ""
+msgstr "Desvincular"
 
 #: src/ui/preferences.blp:102
 msgid "User"
-msgstr ""
+msgstr "Usuário"
 
 #: src/ui/preferences.blp:122
 msgid "Delete Image Cache"
-msgstr ""
+msgstr "Excluir cache de imagens"
 
 #: src/ui/preferences.blp:129
 msgid "Logout"
-msgstr ""
+msgstr "Sair"
 
 #: src/ui/preferences.blp:139
 msgid "Customization"
-msgstr ""
+msgstr "Personalização"
 
 #: src/ui/preferences.blp:142
 msgid "Interface"
-msgstr ""
+msgstr "Interface"
 
 #: src/ui/preferences.blp:144
 msgid "Show Context Button in Rows"
-msgstr ""
+msgstr "Mostrar botão de contexto nas linhas"
 
 #: src/ui/preferences.blp:145
 msgid "The menu can also be shown by right clicking / long pressing"
-msgstr ""
+msgstr "O menu também pode ser exibido clicando com o botão direito ou mantendo pressionado"
 
 #: src/ui/preferences.blp:148
 msgid "Show Labels in Buttons of Pages"
-msgstr ""
+msgstr "Mostrar rótulos nos botões das páginas"
 
 #: src/ui/preferences.blp:151
 msgid "Show Progressbar in Player Footer"
-msgstr ""
+msgstr "Mostrar barra de progresso no rodapé do player"
 
 #: src/ui/preferences.blp:154
 msgid "Make Background Translucent in Player"
-msgstr ""
+msgstr "Tornar o plano de fundo translúcido no player"
 
 #: src/ui/preferences.blp:157
 msgid "Use Sidebar Player When Possible"
-msgstr ""
+msgstr "Usar player lateral quando possível"
 
 #: src/ui/preferences.blp:158
 msgid "Sidebar player is only available when the window is wide enough"
-msgstr ""
+msgstr "O player lateral só está disponível quando a janela é larga o suficiente"
 
 #: src/ui/preferences.blp:161
 msgid "Show Pan Buttons on Carousels"
-msgstr ""
+msgstr "Mostrar botões de navegação nos carrosséis"
 
 #: src/ui/preferences.blp:162
 msgid "Only visible when a carousel has 5 or more items"
-msgstr ""
+msgstr "Visível apenas quando um carrossel possui 5 ou mais itens"
 
 #: src/ui/preferences.blp:165
 msgid "Button Size"
-msgstr ""
+msgstr "Tamanho dos botões"
 
 #: src/ui/preferences.blp:166
 msgid "Affects albums, artists, playlists and songs"
-msgstr ""
+msgstr "Afeta álbuns, artistas, playlists e músicas"
 
 #: src/ui/preferences.blp:172 src/ui/preferences.blp:173
 msgid "Small"
-msgstr ""
+msgstr "Pequeno"
 
 #: src/ui/preferences.blp:177 src/ui/preferences.blp:178
 msgid "Big"
-msgstr ""
+msgstr "Grande"
 
 #: src/ui/preferences.blp:186
 msgid "Dynamic Background"
-msgstr ""
+msgstr "Plano de fundo dinâmico"
 
 #: src/ui/preferences.blp:187
 msgid "Background generated based on the album art of the current song"
-msgstr ""
+msgstr "Plano de fundo gerado com base na arte da capa da música atual"
 
 #: src/ui/preferences.blp:190
 msgid "Use in Main Window"
-msgstr ""
+msgstr "Usar na janela principal"
 
 #: src/ui/preferences.blp:196 src/ui/preferences.blp:197
 #: src/ui/preferences.blp:220 src/ui/preferences.blp:221
 #: src/ui/preferences.blp:244 src/ui/preferences.blp:245
 msgid "Off"
-msgstr ""
+msgstr "Desativado"
 
 #: src/ui/preferences.blp:201 src/ui/preferences.blp:202
 #: src/ui/preferences.blp:225 src/ui/preferences.blp:226
 #: src/ui/preferences.blp:249 src/ui/preferences.blp:250
 msgid "Gradient"
-msgstr ""
+msgstr "Gradiente"
 
 #: src/ui/preferences.blp:206 src/ui/preferences.blp:207
 #: src/ui/preferences.blp:230 src/ui/preferences.blp:231
 #: src/ui/preferences.blp:254 src/ui/preferences.blp:255
 msgid "Blur"
-msgstr ""
+msgstr "Desfoque"
 
 #: src/ui/preferences.blp:214
 msgid "Use in Player"
-msgstr ""
+msgstr "Usar no player"
 
 #: src/ui/preferences.blp:238
 msgid "Use in Pop-out Window"
-msgstr ""
+msgstr "Usar na janela destacada"
 
 #: src/ui/preferences.blp:262
 msgid "Use as Accent Color"
-msgstr ""
+msgstr "Usar como cor de destaque"
 
 #: src/ui/preferences.blp:267
 msgid "Homepage"
-msgstr ""
+msgstr "Página inicial"
 
 #: src/ui/preferences.blp:268
 msgid "Reload homepage to see changes"
-msgstr ""
+msgstr "Recarregue a página inicial para ver as alterações"
 
 #: src/ui/preferences.blp:304
 msgid "Sidebar"
-msgstr ""
+msgstr "Barra lateral"
 
 #: src/ui/preferences.blp:308
 msgid "Visualizer"
-msgstr ""
+msgstr "Visualizador"
 
 #: src/ui/preferences.blp:312 src/ui/window.blp:257
 msgid "Preferences"
-msgstr ""
+msgstr "Preferências"
 
 #: src/ui/preferences.blp:314
 msgid "Show Visualizer in Player"
-msgstr ""
+msgstr "Mostrar visualizador no player"
 
 #: src/ui/preferences.blp:315
 msgid "Show an audio spectrum visualizer on top of the album art in the player"
-msgstr ""
+msgstr "Mostrar um visualizador de espectro de áudio sobre a arte da capa no player"
 
 #: src/ui/preferences.blp:320
 msgid "Appearance"
-msgstr ""
+msgstr "Aparência"
 
 #: src/ui/preferences.blp:324
 msgid "Number of Bars"
-msgstr ""
+msgstr "Número de barras"
 
 #: src/ui/preferences.blp:335
 msgid "Visualizer Type"
-msgstr ""
+msgstr "Tipo de visualizador"
 
 #: src/ui/preferences.blp:341 src/ui/preferences.blp:342
 msgid "Wave"
-msgstr ""
+msgstr "Onda"
 
 #: src/ui/preferences.blp:346 src/ui/preferences.blp:347
 msgid "Bars"
-msgstr ""
+msgstr "Barras"
 
 #: src/ui/preferences.blp:351 src/ui/preferences.blp:352
 msgid "Particles"
-msgstr ""
+msgstr "Partículas"
 
 #: src/ui/preferences.blp:359
 msgid "Fill Mode"
-msgstr ""
+msgstr "Modo de preenchimento"
 
 #: src/ui/preferences.blp:365 src/ui/preferences.blp:366
 msgid "Solid"
-msgstr ""
+msgstr "Sólido"
 
 #: src/ui/preferences.blp:370 src/ui/preferences.blp:371
 msgid "Translucent"
-msgstr ""
+msgstr "Translúcido"
 
 #: src/ui/preferences.blp:375 src/ui/preferences.blp:376
 msgid "Border"
-msgstr ""
+msgstr "Borda"
 
 #: src/ui/preferences.blp:384
 msgid "Color"
-msgstr ""
+msgstr "Cor"
 
 #: src/ui/preferences.blp:388
 msgid "Use Dynamic Color"
-msgstr ""
+msgstr "Usar cor dinâmica"
 
 #: src/ui/preferences.blp:391
 msgid "Invert Color"
-msgstr ""
+msgstr "Inverter cor"
 
 #: src/ui/preferences.blp:395
 msgid "Manual Color"
-msgstr ""
+msgstr "Cor manual"
 
 #: src/ui/preferences.blp:401
 msgid "Visualizer Color"
-msgstr ""
+msgstr "Cor do visualizador"
 
 #: src/ui/shortcuts-dialog.blp:12
 msgid "Show Shortcuts"
-msgstr ""
+msgstr "Mostrar atalhos"
 
 #: src/ui/shortcuts-dialog.blp:16
 msgid "Show Preferences"
-msgstr ""
+msgstr "Mostrar preferências"
 
 #: src/ui/shortcuts-dialog.blp:20
 msgid "Quit"
-msgstr ""
+msgstr "Sair"
 
 #: src/ui/shortcuts-dialog.blp:27
 msgid "Toggle Playback"
-msgstr ""
+msgstr "Alternar reprodução"
 
 #: src/ui/shortcuts-dialog.blp:31
 msgid "Next Song"
-msgstr ""
+msgstr "Próxima música"
 
 #: src/ui/shortcuts-dialog.blp:35
 msgid "Previous Song"
-msgstr ""
+msgstr "Música anterior"
 
 #: src/ui/shortcuts-dialog.blp:39
 msgid "Raise Volume"
-msgstr ""
+msgstr "Aumentar volume"
 
 #: src/ui/shortcuts-dialog.blp:43
 msgid "Lower Volume"
-msgstr ""
+msgstr "Diminuir volume"
 
 #: src/ui/shortcuts-dialog.blp:48
 msgid "Window"
-msgstr ""
+msgstr "Janela"
 
 #: src/ui/shortcuts-dialog.blp:50 src/ui/window.blp:267
 #: src/widgets/playing/popout_window.py:48
 msgid "Toggle Fullscreen"
-msgstr ""
+msgstr "Alternar tela cheia"
 
 #: src/ui/shortcuts-dialog.blp:54 src/ui/window.blp:262
 msgid "Open Pop-Out Window"
-msgstr ""
+msgstr "Abrir janela destacada"
 
 #: src/ui/song/button.blp:31 src/ui/song/small_row.blp:37
 msgid "Song cover art"
-msgstr ""
+msgstr "Arte da capa da música"
 
 #: src/ui/song/button.blp:45
 msgid "Play Indicator"
-msgstr ""
+msgstr "Indicador de reprodução"
 
 #: src/ui/song/queue.blp:47 src/ui/song/queue.blp:49
 msgid "Select All"
-msgstr ""
+msgstr "Selecionar tudo"
 
 #: src/ui/song/row.blp:44
 msgid "Drag icon"
-msgstr ""
+msgstr "Ícone de arrastar"
 
 #: src/ui/song/row.blp:142
 msgid "Selection box"
-msgstr ""
+msgstr "Caixa de seleção"
 
 #: src/ui/window.blp:91
 msgid "Play Random Queue"
-msgstr ""
+msgstr "Reproduzir fila aleatória"
 
 #: src/ui/window.blp:99
 msgid "Menu"
-msgstr ""
+msgstr "Menu"
 
 #: src/ui/window.blp:127
 msgid "Random Albums"
-msgstr ""
+msgstr "Álbuns aleatórios"
 
 #: src/ui/window.blp:131
 msgid "Favorite Albums"
-msgstr ""
+msgstr "Álbuns favoritos"
 
 #: src/ui/window.blp:135
 msgid "Newest Albums"
-msgstr ""
+msgstr "Álbuns mais recentes"
 
 #: src/ui/window.blp:139
 msgid "Recent Albums"
-msgstr ""
+msgstr "Álbuns recentes"
 
 #: src/ui/window.blp:143
 msgid "Frequent Albums"
-msgstr ""
+msgstr "Álbuns frequentes"
 
 #: src/ui/window.blp:166
 msgid "Player"
-msgstr ""
+msgstr "Player"
 
 #: src/ui/window.blp:272
 msgid "See Last Nocturne Playback"
-msgstr ""
+msgstr "Ver a última retrospectiva do Nocturne"
 
 #: src/ui/window.blp:277
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "Atalhos de teclado"
 
 #: src/ui/window.blp:282
 msgid "About Nocturne"
-msgstr ""
+msgstr "Sobre o Nocturne"
 
 #: src/widgets/album/button.py:95 src/widgets/album/page.py:150
 #: src/widgets/artist/page.py:130 src/widgets/playing/control_page.py:194
 #: src/widgets/song/row.py:188
 msgid "Not Favorite"
-msgstr ""
+msgstr "Não é favorito"
 
 #: src/widgets/album/page.py:18
 #, python-brace-format
 msgid "Disc {}"
-msgstr ""
+msgstr "Disco {}"
 
 #: src/widgets/artist/button.py:56 src/widgets/artist/row.py:46
 #, python-brace-format
 msgid "{} Album"
 msgid_plural "{} Albums"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{} álbum"
+msgstr[1] "{} álbuns"
 
 #: src/widgets/artist/page.py:48
 msgid "Top Songs"
-msgstr ""
+msgstr "Músicas mais populares"
 
 #: src/widgets/artist/page.py:58
 msgid "Related Artists"
-msgstr ""
+msgstr "Artistas relacionados"
 
 #: src/widgets/artist/page.py:113
 msgid "Author"
-msgstr ""
+msgstr "Autor"
 
 #: src/widgets/containers/context.py:50
 #, python-brace-format
 msgid "{} Stars"
-msgstr ""
+msgstr "{} estrelas"
 
 #: src/widgets/lyrics/dialog.py:54
 msgid "No Timestamp"
-msgstr ""
+msgstr "Sem marca de tempo"
 
 #: src/widgets/pages/login.py:52 src/widgets/pages/login.py:115
 msgid "Running"
-msgstr ""
+msgstr "Em execução"
 
 #: src/widgets/pages/login.py:86
 msgid "Extra Menu"
-msgstr ""
+msgstr "Menu adicional"
 
 #: src/widgets/pages/login.py:104 src/widgets/pages/setup.py:83
 msgid "Music Library"
-msgstr ""
+msgstr "Biblioteca de músicas"
 
 #: src/widgets/pages/login.py:114
 msgid "Restarted"
-msgstr ""
+msgstr "Reiniciado"
 
 #: src/widgets/pages/login.py:153
 msgid "Quick Connect"
-msgstr ""
+msgstr "Conexão rápida"
 
 #: src/widgets/pages/login.py:154
 msgid "Error getting code"
-msgstr ""
+msgstr "Erro ao obter o código"
 
 #: src/widgets/pages/login.py:156
 msgid "Quick Connect Page"
-msgstr ""
+msgstr "Página de conexão rápida"
 
 #: src/widgets/pages/playback.py:29
 #, python-brace-format
 msgid "Nocturne Playback ~ {}"
-msgstr ""
+msgstr "Retrospectiva do Nocturne ~ {}"
 
 #: src/widgets/pages/playback.py:48 src/widgets/pages/playback.py:57
 #, python-brace-format
 msgid "{} Plays"
-msgstr ""
+msgstr "{} reproduções"
 
 #: src/widgets/pages/setup.py:70
 msgid "Installing"
-msgstr ""
+msgstr "Instalando"
 
 #: src/widgets/pages/welcome.py:20 src/widgets/pages/welcome.py:22
 msgid "Integration"
-msgstr ""
+msgstr "Integração"
 
 #: src/widgets/playing/lyrics_page.py:246
 msgid "LRC File"
-msgstr ""
+msgstr "Arquivo LRC"
 
 #: src/widgets/playing/player.py:621
 msgid "Warning: Song changed but volume is set to 0"
-msgstr ""
+msgstr "Aviso: a música mudou, mas o volume está definido como 0"
 
 #: src/widgets/playlist/button.py:63 src/widgets/playlist/page.py:116
 #: src/widgets/playlist/row.py:47 src/widgets/playlist/selector_row.py:36
 #, python-brace-format
 msgid "{} Song"
 msgid_plural "{} Songs"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{} música"
+msgstr[1] "{} músicas"
 
 #: src/widgets/playlist/dialog.py:55
 msgid "New Playlist"
-msgstr ""
+msgstr "Nova playlist"
 
 #: src/widgets/playlist/selector_row.py:33
 #, python-brace-format
 msgid "Add Songs to '{}'"
-msgstr ""
+msgstr "Adicionar músicas à playlist '{}'"
 
 #: src/widgets/song/details_dialog.py:22
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 #: src/widgets/song/details_dialog.py:22
 msgid "No"
-msgstr ""
+msgstr "Não"
 
 #: src/widgets/song/details_dialog.py:27
 msgid "Not Found"
-msgstr ""
+msgstr "Não encontrado"
 
 #: src/widgets/song/row.py:147 src/widgets/song/row.py:152
 msgid "Multiple Artists"
-msgstr ""
+msgstr "Vários artistas"
 
 #: src/window.py:214
 #, python-brace-format
 msgid "Your Playback queue for {} is available!"
-msgstr ""
+msgstr "Sua fila de reprodução de {} está disponível!"
 
 #: src/window.py:216
 msgid "Show"
-msgstr ""
+msgstr "Mostrar"
 
 #: src/window.py:217
 msgid "Later"
-msgstr ""
+msgstr "Mais tarde"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,0 +1,1915 @@
+# Portuguese translations for PACKAGE package
+# Traduções em português brasileiro para o pacote PACKAGE.
+# Copyright (C) 2026 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Rikelry <153693133+Rikelry@users.noreply.github.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-21 03:36-0300\n"
+"PO-Revision-Date: 2026-07-21 10:50-0300\n"
+"Last-Translator: Rikelry <153693133+Rikelry@users.noreply.github.com>\n"
+"Language-Team: Brazilian Portuguese\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: data/com.jeffser.Nocturne.desktop.in:2
+#: data/com.jeffser.Nocturne.metainfo.xml.in:7
+msgid "Nocturne"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.desktop.in:10
+msgid "GTK;Navidrome;Jellyfin;Music;"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:8
+msgid "Bring your music library together"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:10
+msgid "A modern music client"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:11
+msgid "Features"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:13
+msgid "Compatibility with Jellyfin, OpenSubsonic, Bandcamp and local files"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:14
+msgid "Exploration by songs, artists, albums, radios and playlists"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:15
+msgid "Playlist management"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:16
+msgid "Audio equalizer and audio visualizer"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:17
+msgid "Mpris integration"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:18
+msgid "Integrated Navidrome instance management"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:19
+msgid "Automatic lyrics fetching"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:20
+msgid "Downloads and offline mode"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:21
+msgid "Cool interface"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:26
+msgid "Jeffry Samuel Eduarte Rojas"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:66
+msgid "Main homepage"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:70
+msgid "Song queue"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:74
+#: src/ui/playing/popout_window.blp:93 src/ui/window.blp:182
+#: src/ui/window.blp:234
+msgid "Lyrics"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:78
+msgid "Song list"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:82
+msgid "Album page"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:86
+msgid "Mini Player"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:91
+msgid "opensubsonic"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:92
+msgid "bandcamp"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:93
+msgid "navidrome"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:94
+msgid "jellyfin"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:95
+msgid "music"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.metainfo.xml.in:96
+msgid "gtk"
+msgstr ""
+
+#: data/com.jeffser.Nocturne.SearchProvider.desktop.in:3
+msgid "Nocturne Search Provider"
+msgstr ""
+
+#: src/actions.py:140 src/widgets/pages/login.py:117
+msgid "Error"
+msgstr ""
+
+#: src/actions.py:141
+msgid "No details provided"
+msgstr ""
+
+#: src/actions.py:143 src/actions.py:284 src/preferences.py:486
+#: src/ui/song/queue.blp:40
+msgid "Close"
+msgstr ""
+
+#: src/actions.py:181
+#, python-brace-format
+msgid "Not enough data found for Nocturne Playback ({})"
+msgstr ""
+
+#: src/actions.py:281 src/ui/song/row.blp:72
+msgid "External File"
+msgstr ""
+
+#: src/actions.py:282
+msgid ""
+"This track was loaded from an external file, this means it will have less "
+"features compared to a track inside the library"
+msgstr ""
+
+#: src/actions.py:302
+msgid "Navidrome server deleted successfully"
+msgstr ""
+
+#: src/actions.py:311
+msgid "Delete Navidrome Server"
+msgstr ""
+
+#: src/actions.py:312
+msgid "Are you sure you want to delete the integrated Navidrome server?"
+msgstr ""
+
+#: src/actions.py:314 src/actions.py:453 src/actions.py:487 src/actions.py:687
+#: src/actions.py:765 src/preferences.py:431 src/ui/lyrics/dialog.blp:16
+#: src/ui/lyrics/dialog.blp:17 src/widgets/pages/login.py:162
+msgid "Cancel"
+msgstr ""
+
+#: src/actions.py:315
+msgid "Keep Data"
+msgstr ""
+
+#: src/actions.py:316
+msgid "Delete Everything"
+msgstr ""
+
+#: src/actions.py:401
+msgid "No Name"
+msgstr ""
+
+#: src/actions.py:420
+msgid "Radio updated successfully"
+msgstr ""
+
+#: src/actions.py:420
+msgid "Radio added successfully"
+msgstr ""
+
+#: src/actions.py:427
+msgid "Error updating radio"
+msgstr ""
+
+#: src/actions.py:427
+msgid "Error adding radio"
+msgstr ""
+
+#: src/actions.py:438 src/actions.py:679
+msgid "Name"
+msgstr ""
+
+#: src/actions.py:443
+msgid "Stream Url"
+msgstr ""
+
+#: src/actions.py:450
+msgid "Update Radio Station"
+msgstr ""
+
+#: src/actions.py:450
+msgid "Add Radio Station"
+msgstr ""
+
+#: src/actions.py:454 src/preferences.py:432 src/ui/lyrics/dialog.blp:23
+#: src/ui/lyrics/dialog.blp:24
+msgid "Save"
+msgstr ""
+
+#: src/actions.py:467
+msgid "Radio deleted successfully"
+msgstr ""
+
+#: src/actions.py:471
+msgid "Error deleting radio"
+msgstr ""
+
+#: src/actions.py:484
+msgid "Delete Radio Station"
+msgstr ""
+
+#: src/actions.py:485 src/actions.py:763
+#, python-brace-format
+msgid "Are you sure you want to delete '{}'?"
+msgstr ""
+
+#: src/actions.py:488 src/actions.py:766 src/constants.py:533
+#: src/constants.py:581
+msgid "Delete"
+msgstr ""
+
+#: src/actions.py:507 src/actions.py:519 src/actions.py:521 src/actions.py:585
+#: src/actions.py:636
+msgid "Playing Next"
+msgstr ""
+
+#: src/actions.py:511 src/actions.py:526 src/actions.py:528 src/actions.py:592
+#: src/actions.py:643
+msgid "Playing Later"
+msgstr ""
+
+#: src/actions.py:519 src/actions.py:526 src/actions.py:876 src/actions.py:1001
+#: src/widgets/playlist/dialog.py:31
+#, python-brace-format
+msgid "{} Songs"
+msgstr ""
+
+#: src/actions.py:553
+msgid "Lyrics Saved"
+msgstr ""
+
+#: src/actions.py:661
+msgid "Playlist updated successfully"
+msgstr ""
+
+#: src/actions.py:661
+msgid "Playlist created successfully"
+msgstr ""
+
+#: src/actions.py:663
+msgid "Error updating playlist"
+msgstr ""
+
+#: src/actions.py:663
+msgid "Error creating playlist"
+msgstr ""
+
+#: src/actions.py:684
+msgid "Update Playlist"
+msgstr ""
+
+#: src/actions.py:684 src/ui/pages/playlists.blp:41
+msgid "Create Playlist"
+msgstr ""
+
+#: src/actions.py:688
+msgid "Update"
+msgstr ""
+
+#: src/actions.py:688
+msgid "Create"
+msgstr ""
+
+#: src/actions.py:701
+#, python-brace-format
+msgid "{} Song Removed"
+msgid_plural "{} Songs Removed"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/actions.py:726 src/actions.py:740
+#, python-brace-format
+msgid "{} Song Added"
+msgid_plural "{} Songs Added"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/actions.py:744 src/actions.py:881
+#, python-brace-format
+msgid "{} Song Skipped"
+msgid_plural "{} Songs Skipped"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/actions.py:755
+msgid "Playlist Deleted"
+msgstr ""
+
+#: src/actions.py:762
+msgid "Delete Playlist"
+msgstr ""
+
+#: src/actions.py:812
+msgid "No songs found"
+msgstr ""
+
+#: src/actions.py:853 src/actions.py:877 src/actions.py:912 src/actions.py:945
+msgid "Download Started"
+msgstr ""
+
+#: src/actions.py:860 src/actions.py:888 src/actions.py:895 src/actions.py:928
+#: src/actions.py:961
+msgid "Already Downloaded"
+msgstr ""
+
+#: src/actions.py:882
+#, python-brace-format
+msgid "{} Song ({})"
+msgid_plural "{} Songs ({})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/actions.py:894
+msgid "Download Skipped"
+msgstr ""
+
+#: src/actions.py:916 src/actions.py:949
+#, python-brace-format
+msgid "Download Started ({} Song Skipped)"
+msgid_plural "Download Started ({} Songs Skipped)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/actions.py:985 src/actions.py:1002
+msgid "Deleted"
+msgstr ""
+
+#: src/constants.py:343 src/ui/playing/playback_mode_button.blp:5
+msgid "Consecutive"
+msgstr ""
+
+#: src/constants.py:347
+msgid "Repeat All"
+msgstr ""
+
+#: src/constants.py:351
+msgid "Repeat One"
+msgstr ""
+
+#: src/constants.py:356
+#, python-brace-format
+msgid "Low ({})"
+msgstr ""
+
+#: src/constants.py:357
+#, python-brace-format
+msgid "Medium ({})"
+msgstr ""
+
+#: src/constants.py:358
+#, python-brace-format
+msgid "High ({})"
+msgstr ""
+
+#: src/constants.py:359
+#, python-brace-format
+msgid "Ultra ({})"
+msgstr ""
+
+#: src/constants.py:360
+msgid "Original File"
+msgstr ""
+
+#. Item
+#: src/constants.py:367 src/ui/pages/home.blp:5
+msgid "Home"
+msgstr ""
+
+#. Item
+#. list
+#: src/constants.py:372 src/integrations/models.py:163
+#: src/ui/pages/artists.blp:5 src/ui/pages/artists.blp:28
+#: src/ui/preferences.blp:286 src/widgets/pages/home.py:54
+msgid "Artists"
+msgstr ""
+
+#. Section
+#: src/constants.py:379 src/ui/pages/albums_all.blp:5
+#: src/ui/pages/albums_all.blp:28 src/ui/preferences.blp:278
+#: src/widgets/artist/page.py:53 src/widgets/pages/home.py:49
+msgid "Albums"
+msgstr ""
+
+#. Item
+#: src/constants.py:382 src/constants.py:417 src/constants.py:437
+#: src/window.py:155
+msgid "All"
+msgstr ""
+
+#. Item
+#: src/constants.py:387
+msgid "Random"
+msgstr ""
+
+#. Item
+#: src/constants.py:392 src/constants.py:422
+msgid "Favorites"
+msgstr ""
+
+#. Item
+#: src/constants.py:397
+msgid "Recently Added"
+msgstr ""
+
+#. Item
+#: src/constants.py:402
+msgid "Recently Played"
+msgstr ""
+
+#. Item
+#: src/constants.py:407
+msgid "Most Played"
+msgstr ""
+
+#. Section
+#: src/constants.py:414 src/ui/pages/songs_all.blp:5
+#: src/ui/pages/songs_all.blp:28 src/ui/preferences.blp:270
+#: src/widgets/album/page.py:45 src/widgets/pages/home.py:38
+#: src/widgets/playlist/page.py:29
+msgid "Songs"
+msgstr ""
+
+#. Item
+#: src/constants.py:427 src/ui/pages/radios.blp:5 src/ui/pages/radios.blp:13
+msgid "Radios"
+msgstr ""
+
+#. Section
+#: src/constants.py:434 src/ui/pages/playlists.blp:5
+#: src/ui/pages/playlists.blp:28 src/ui/preferences.blp:294
+#: src/widgets/pages/home.py:59
+msgid "Playlists"
+msgstr ""
+
+#: src/constants.py:447 src/constants.py:498 src/ui/lyrics/dialog.blp:47
+#: src/ui/playing/control_page.blp:172 src/ui/playing/footer.blp:114
+#: src/ui/song/queue.blp:55 src/ui/song/queue.blp:57
+msgid "Play"
+msgstr ""
+
+#: src/constants.py:452 src/constants.py:485 src/constants.py:508
+msgid "Shuffle"
+msgstr ""
+
+#: src/constants.py:457 src/constants.py:513 src/constants.py:546
+#: src/ui/song/queue.blp:63 src/ui/song/queue.blp:65
+msgid "Play Next"
+msgstr ""
+
+#: src/constants.py:462 src/constants.py:518 src/constants.py:551
+#: src/ui/song/queue.blp:71 src/ui/song/queue.blp:73
+msgid "Play Later"
+msgstr ""
+
+#: src/constants.py:467 src/constants.py:561 src/ui/song/queue.blp:79
+#: src/ui/song/queue.blp:81
+msgid "Add To Playlist"
+msgstr ""
+
+#: src/constants.py:472 src/constants.py:523 src/constants.py:566
+#: src/ui/pages/setup.blp:23 src/ui/playing/lyrics_page.blp:167
+#: src/ui/playing/lyrics_page.blp:170 src/ui/song/queue.blp:87
+#: src/ui/song/queue.blp:89
+msgid "Download"
+msgstr ""
+
+#: src/constants.py:477 src/constants.py:576
+#: src/nocturne_search_provider.py.in:11 src/ui/playing/control_page.blp:83
+msgid "Show Artist"
+msgstr ""
+
+#: src/constants.py:490 src/ui/playing/lyrics_page.blp:146
+#: src/widgets/song/row.py:109
+msgid "Radio"
+msgstr ""
+
+#: src/constants.py:503
+msgid "Resume"
+msgstr ""
+
+#: src/constants.py:528 src/constants.py:556
+msgid "Edit"
+msgstr ""
+
+#: src/constants.py:542
+msgid "Select"
+msgstr ""
+
+#: src/constants.py:571 src/ui/album/button.blp:49
+#: src/ui/playing/control_page.blp:98
+msgid "Show Album"
+msgstr ""
+
+#: src/constants.py:587 src/ui/song/queue.blp:98 src/ui/song/queue.blp:100
+msgid "Remove"
+msgstr ""
+
+#: src/constants.py:592 src/ui/song/queue.blp:109 src/ui/song/queue.blp:111
+msgid "Delete Download"
+msgstr ""
+
+#: src/constants.py:598 src/main.py:156
+msgid "Show Details"
+msgstr ""
+
+#: src/constants.py:609
+msgid "Visit Webpage"
+msgstr ""
+
+#: src/constants.py:615
+msgid "Update Server"
+msgstr ""
+
+#: src/constants.py:620
+msgid "Delete Server"
+msgstr ""
+
+#: src/constants.py:629
+msgid "Edit Lyrics"
+msgstr ""
+
+#: src/constants.py:634
+msgid "Remove Lyrics"
+msgstr ""
+
+#: src/integrations/base.py:296
+msgid "Could not generate SQL database"
+msgstr ""
+
+#: src/integrations/discord_rpc.py:171
+msgid "Browsing"
+msgstr ""
+
+#: src/integrations/discord_rpc.py:189
+msgid "Listening to music"
+msgstr ""
+
+#: src/integrations/jellyfin.py:18
+msgid "Connect to a Jellyfin server."
+msgstr ""
+
+#: src/integrations/jellyfin.py:22
+msgid "Jellyfin"
+msgstr ""
+
+#: src/integrations/jellyfin.py:23
+msgid "Use an existing Jellyfin instance"
+msgstr ""
+
+#: src/integrations/jellyfin.py:258
+msgid "Could not log in"
+msgstr ""
+
+#: src/integrations/jellyfin.py:1041
+msgid "Unknown"
+msgstr ""
+
+#: src/integrations/local.py:20 src/integrations/local.py:26
+#: src/integrations/local.py:668
+msgid "Local Files"
+msgstr ""
+
+#: src/integrations/local.py:21
+msgid ""
+"Let Nocturne load your local files directly, for big libraries it is "
+"recommended to use a dedicated server."
+msgstr ""
+
+#: src/integrations/local.py:23 src/ui/pages/setup.blp:67
+#: src/ui/pages/setup.blp:68
+msgid "Continue"
+msgstr ""
+
+#: src/integrations/local.py:27
+msgid "Limited functionality"
+msgstr ""
+
+#. load songs, albums, artists
+#: src/integrations/local.py:68
+msgid "Loading Songs"
+msgstr ""
+
+#: src/integrations/local.py:138 src/integrations/navidrome.py:760
+msgid "Could not locate path, try again"
+msgstr ""
+
+#: src/integrations/local.py:317
+msgid "No Album"
+msgstr ""
+
+#: src/integrations/local.py:686 src/integrations/local.py:695
+msgid "Offline Mode"
+msgstr ""
+
+#: src/integrations/local.py:687
+msgid "Access your downloads"
+msgstr ""
+
+#: src/integrations/models.py:142 src/ui/album/page.blp:5
+#: src/widgets/album/page.py:129
+msgid "Album"
+msgstr ""
+
+#: src/integrations/models.py:144
+msgid "Display Artist"
+msgstr ""
+
+#: src/integrations/models.py:146
+msgid "MusicBrainz ID"
+msgstr ""
+
+#: src/integrations/models.py:147
+msgid "Track Number"
+msgstr ""
+
+#: src/integrations/models.py:148
+msgid "Year"
+msgstr ""
+
+#: src/integrations/models.py:149
+msgid "Size"
+msgstr ""
+
+#: src/integrations/models.py:150
+msgid "Suffix"
+msgstr ""
+
+#: src/integrations/models.py:151 src/widgets/album/button.py:90
+#: src/widgets/album/page.py:145 src/widgets/artist/page.py:125
+#: src/widgets/playing/control_page.py:189 src/widgets/song/row.py:183
+msgid "Favorite"
+msgstr ""
+
+#: src/integrations/models.py:152
+msgid "Duration"
+msgstr ""
+
+#: src/integrations/models.py:154
+msgid "Bit Rate"
+msgstr ""
+
+#: src/integrations/models.py:155
+msgid "Bit Depth"
+msgstr ""
+
+#: src/integrations/models.py:156
+msgid "Sampling Rate"
+msgstr ""
+
+#: src/integrations/models.py:157
+msgid "Channel Count"
+msgstr ""
+
+#: src/integrations/models.py:159
+msgid "Path"
+msgstr ""
+
+#: src/integrations/models.py:160
+msgid "Disc Number"
+msgstr ""
+
+#: src/integrations/models.py:161
+msgid "BPM"
+msgstr ""
+
+#: src/integrations/models.py:162
+msgid "Genres"
+msgstr ""
+
+#. list
+#: src/integrations/models.py:164
+msgid "Track Gain"
+msgstr ""
+
+#: src/integrations/models.py:165
+msgid "Album Gain"
+msgstr ""
+
+#: src/integrations/navidrome.py:19
+msgid "Connect to an OpenSubsonic server like Navidrome."
+msgstr ""
+
+#: src/integrations/navidrome.py:23
+msgid "External Server"
+msgstr ""
+
+#: src/integrations/navidrome.py:24
+msgid "Use an existing OpenSubsonic instance"
+msgstr ""
+
+#: src/integrations/navidrome.py:172
+msgid "Server returned an error"
+msgstr ""
+
+#: src/integrations/navidrome.py:172
+msgid "Unknown Error"
+msgstr ""
+
+#: src/integrations/navidrome.py:735 src/integrations/navidrome.py:744
+msgid "Managed Server"
+msgstr ""
+
+#: src/integrations/navidrome.py:736
+msgid "Connect to a Navidrome instance directly managed by Nocturne."
+msgstr ""
+
+#: src/integrations/navidrome.py:739
+msgid "Manage Server"
+msgstr ""
+
+#: src/integrations/navidrome.py:745
+msgid "Create and use a Navidrome instance"
+msgstr ""
+
+#: src/integrations/navidrome.py:804
+msgid "Important: Use your Subsonic login information."
+msgstr ""
+
+#: src/integrations/navidrome.py:807
+msgid "Bandcamp User Settings"
+msgstr ""
+
+#: src/integrations/navidrome.py:813
+msgid "Explore your online library"
+msgstr ""
+
+#: src/main.py:94
+msgid "Music is Playing"
+msgstr ""
+
+#: src/main.py:107
+msgid "Fullscreen Player Active"
+msgstr ""
+
+#: src/main.py:153
+msgid "Login Failed"
+msgstr ""
+
+#: src/nocturne_search_provider.py.in:12 src/ui/album/button.blp:21
+msgid "Play Album"
+msgstr ""
+
+#: src/nocturne_search_provider.py.in:13 src/ui/song/button.blp:16
+msgid "Play Song"
+msgstr ""
+
+#: src/nocturne_search_provider.py.in:14 src/ui/playlist/button.blp:28
+msgid "Play Playlist"
+msgstr ""
+
+#: src/nocturne_search_provider.py.in:113
+msgid "Open"
+msgstr ""
+
+#: src/preferences.py:420
+msgid "Settings Page"
+msgstr ""
+
+#: src/preferences.py:423
+msgid "User Token"
+msgstr ""
+
+#: src/preferences.py:427
+msgid "Link ListenBrainz"
+msgstr ""
+
+#: src/preferences.py:428
+msgid "Connect your ListenBrainz account with a user token"
+msgstr ""
+
+#: src/preferences.py:476
+msgid "Flatpak Sandbox Warning"
+msgstr ""
+
+#: src/preferences.py:477
+msgid ""
+"To connect to Discord, an additional permission is required, once you run "
+"the following command, please restart Nocturne"
+msgstr ""
+
+#: src/ui/album/button.blp:36 src/ui/album/page.blp:152
+#: src/ui/artist/page.blp:150 src/ui/song/row.blp:115
+msgid "Toggle star"
+msgstr ""
+
+#: src/ui/album/button.blp:61 src/ui/album/page.blp:50 src/ui/album/row.blp:32
+msgid "Album cover art"
+msgstr ""
+
+#: src/ui/album/button.blp:87
+msgid "Enter album page"
+msgstr ""
+
+#: src/ui/album/button.blp:128 src/ui/album/page.blp:85
+#: src/ui/song/button.blp:81
+msgid "Enter artist page"
+msgstr ""
+
+#: src/ui/album/page.blp:95 src/ui/artist/page.blp:93
+#: src/ui/playing/control_page.blp:228 src/widgets/containers/context.py:50
+msgid "1 Star"
+msgstr ""
+
+#: src/ui/album/page.blp:104 src/ui/artist/page.blp:102
+#: src/ui/playing/control_page.blp:237
+msgid "2 Stars"
+msgstr ""
+
+#: src/ui/album/page.blp:113 src/ui/artist/page.blp:111
+#: src/ui/playing/control_page.blp:246
+msgid "3 Stars"
+msgstr ""
+
+#: src/ui/album/page.blp:122 src/ui/artist/page.blp:120
+#: src/ui/playing/control_page.blp:255
+msgid "4 Stars"
+msgstr ""
+
+#: src/ui/album/page.blp:131 src/ui/artist/page.blp:129
+#: src/ui/playing/control_page.blp:264
+msgid "5 Stars"
+msgstr ""
+
+#: src/ui/album/row.blp:48 src/ui/artist/row.blp:40 src/ui/playlist/row.blp:48
+#: src/ui/song/row.blp:130
+msgid "Options"
+msgstr ""
+
+#: src/ui/artist/page.blp:5
+msgid "Artist"
+msgstr ""
+
+#: src/ui/artist/page.blp:83
+msgid "Expand Biography"
+msgstr ""
+
+#: src/ui/containers/carousel.blp:24 src/ui/containers/carousel.blp:26
+#: src/ui/containers/wrapbox.blp:19 src/ui/containers/wrapbox.blp:21
+#: src/ui/pages/albums_all.blp:15 src/ui/pages/artists.blp:15
+#: src/ui/pages/playlists.blp:15 src/ui/pages/songs_all.blp:15
+#: src/ui/pages/songs_starred.blp:15 src/ui/song/queue.blp:16
+#: src/ui/song/queue.blp:18
+msgid "List"
+msgstr ""
+
+#: src/ui/containers/carousel.blp:41
+msgid "Pan to the Left"
+msgstr ""
+
+#: src/ui/containers/carousel.blp:47
+msgid "Pan to the Right"
+msgstr ""
+
+#: src/ui/containers/download_row.blp:31
+msgid "Downloaded"
+msgstr ""
+
+#: src/ui/containers/download_row.blp:52
+msgid "Remove From Queue"
+msgstr ""
+
+#: src/ui/containers/downloads_queue_button.blp:10
+msgid "Downloads Queue"
+msgstr ""
+
+#: src/ui/containers/downloads_queue_button.blp:11
+msgid "Downloaded songs are available in offline mode"
+msgstr ""
+
+#: src/ui/containers/downloads_queue_button.blp:19
+msgid "Clear Done Downloads"
+msgstr ""
+
+#: src/ui/lyrics/dialog.blp:5
+msgid "Lyrics Editor"
+msgstr ""
+
+#: src/ui/lyrics/dialog.blp:61 src/ui/playing/control_page.blp:187
+#: src/ui/playing/footer.blp:129
+msgid "Pause"
+msgstr ""
+
+#: src/ui/lyrics/dialog.blp:98 src/ui/playing/control_page.blp:122
+msgid "Current song progress bar"
+msgstr ""
+
+#: src/ui/lyrics/dialog.blp:103
+msgid "Set Next Line Timestamp to Now"
+msgstr ""
+
+#: src/ui/lyrics/dialog.blp:112
+msgid "Add Line at Timestamp"
+msgstr ""
+
+#: src/ui/lyrics/dialog.blp:133
+msgid "No Lyrics"
+msgstr ""
+
+#: src/ui/lyrics/dialog.blp:134
+msgid "No lyrics found for this track, to get started add a new line"
+msgstr ""
+
+#: src/ui/lyrics/edit_row.blp:9
+msgid "Timestamp"
+msgstr ""
+
+#: src/ui/lyrics/edit_row.blp:15 src/ui/lyrics/edit_row.blp:17
+msgid "Go to Timestamp"
+msgstr ""
+
+#: src/ui/lyrics/edit_row.blp:27 src/ui/lyrics/edit_row.blp:29
+msgid "Set Current Timestamp"
+msgstr ""
+
+#: src/ui/lyrics/edit_row.blp:39 src/ui/lyrics/edit_row.blp:41
+msgid "Remove Line"
+msgstr ""
+
+#: src/ui/pages/albums_all.blp:20 src/ui/pages/artists.blp:20
+#: src/ui/pages/playlists.blp:20 src/ui/pages/songs_all.blp:20
+#: src/ui/pages/songs_starred.blp:20
+msgid "Grid"
+msgstr ""
+
+#: src/ui/pages/albums_all.blp:31
+msgid "Search albums"
+msgstr ""
+
+#: src/ui/pages/albums_all.blp:99 src/ui/pages/albums.blp:53
+#: src/ui/pages/artists.blp:98 src/ui/pages/playlists.blp:111
+#: src/ui/pages/songs_all.blp:100
+msgid "Reached End of List"
+msgstr ""
+
+#: src/ui/pages/albums_all.blp:115 src/ui/pages/albums.blp:69
+msgid "No Albums Found"
+msgstr ""
+
+#: src/ui/pages/artists.blp:31
+msgid "Search artists"
+msgstr ""
+
+#: src/ui/pages/artists.blp:114
+msgid "No Artists Found"
+msgstr ""
+
+#: src/ui/pages/home.blp:15
+msgid "Toggle Search"
+msgstr ""
+
+#: src/ui/pages/home.blp:24 src/ui/shortcuts-dialog.blp:8
+msgid "Search"
+msgstr ""
+
+#: src/ui/pages/home.blp:68
+msgid "No Elements Found"
+msgstr ""
+
+#. Login Button
+#: src/ui/pages/login.blp:5 src/ui/pages/login.blp:16
+#: src/ui/pages/login.blp:107 src/ui/pages/login.blp:108
+#: src/widgets/pages/login.py:38 src/widgets/pages/login.py:78
+msgid "Login"
+msgstr ""
+
+#: src/ui/pages/login.blp:36
+msgid "Server Status"
+msgstr ""
+
+#: src/ui/pages/login.blp:37 src/widgets/pages/login.py:52
+msgid "Not Running"
+msgstr ""
+
+#: src/ui/pages/login.blp:38
+msgid "Restart Instance"
+msgstr ""
+
+#: src/ui/pages/login.blp:50
+msgid "Manage Navidrome Server"
+msgstr ""
+
+#: src/ui/pages/login.blp:60
+msgid "Url"
+msgstr ""
+
+#: src/ui/pages/login.blp:67
+msgid "More Options"
+msgstr ""
+
+#: src/ui/pages/login.blp:73
+msgid "Trust Server Certificates"
+msgstr ""
+
+#: src/ui/pages/login.blp:81
+msgid "Library Directory"
+msgstr ""
+
+#: src/ui/pages/login.blp:93
+msgid "Username"
+msgstr ""
+
+#: src/ui/pages/login.blp:97
+msgid "Password"
+msgstr ""
+
+#: src/ui/pages/login.blp:117 src/ui/pages/login.blp:118
+msgid "Use Quick Connect"
+msgstr ""
+
+#: src/ui/pages/playback.blp:5 src/ui/shortcuts-dialog.blp:25
+msgid "Playback"
+msgstr ""
+
+#: src/ui/pages/playback.blp:17
+msgid "Go Home"
+msgstr ""
+
+#: src/ui/pages/playback.blp:24
+msgid "Toggle Visualizer"
+msgstr ""
+
+#: src/ui/pages/playback.blp:54 src/window.py:213
+msgid "Nocturne Playback"
+msgstr ""
+
+#: src/ui/pages/playback.blp:64
+msgid "These are your most played songs from last month"
+msgstr ""
+
+#: src/ui/pages/playback.blp:83 src/ui/pages/playback.blp:85
+msgid "Save Playlist"
+msgstr ""
+
+#: src/ui/pages/playback.blp:98 src/ui/pages/playback.blp:100
+msgid "Playlist Added"
+msgstr ""
+
+#: src/ui/pages/playback.blp:123
+msgid "Thank you for using Nocturne!"
+msgstr ""
+
+#: src/ui/pages/playlists.blp:31
+msgid "Search playlists"
+msgstr ""
+
+#: src/ui/pages/playlists.blp:127
+msgid "No Playlists Found"
+msgstr ""
+
+#: src/ui/pages/radios.blp:16
+msgid "Search radios"
+msgstr ""
+
+#: src/ui/pages/radios.blp:26
+msgid "Add Radio"
+msgstr ""
+
+#: src/ui/pages/radios.blp:61
+msgid "No Radios Found"
+msgstr ""
+
+#: src/ui/pages/setup.blp:5
+msgid "Setup"
+msgstr ""
+
+#: src/ui/pages/setup.blp:19
+msgid "Navidrome Download"
+msgstr ""
+
+#: src/ui/pages/setup.blp:20
+msgid "Nocturne will download Navidrome automatically"
+msgstr ""
+
+#: src/ui/pages/setup.blp:22
+msgid "Download (~20 mb)"
+msgstr ""
+
+#: src/ui/pages/setup.blp:34
+msgid "Downloading"
+msgstr ""
+
+#: src/ui/pages/setup.blp:46
+msgid "An Error Occurred"
+msgstr ""
+
+#: src/ui/pages/setup.blp:47
+msgid "Please try again later"
+msgstr ""
+
+#: src/ui/pages/setup.blp:55
+msgid "Download Successful"
+msgstr ""
+
+#: src/ui/pages/setup.blp:56
+msgid ""
+"Before continuing make sure you create an admin account and also make sure "
+"all your tracks are inside your music directory"
+msgstr ""
+
+#: src/ui/pages/setup.blp:63
+msgid "Instance Webpage"
+msgstr ""
+
+#: src/ui/pages/songs_all.blp:31
+msgid "Search songs"
+msgstr ""
+
+#: src/ui/pages/songs_all.blp:116 src/ui/pages/songs_starred.blp:96
+#: src/ui/song/queue.blp:137
+msgid "No Songs Found"
+msgstr ""
+
+#: src/ui/pages/songs_starred.blp:5 src/ui/pages/songs_starred.blp:28
+msgid "Favorite Songs"
+msgstr ""
+
+#: src/ui/pages/songs_starred.blp:31
+msgid "Search favorite songs"
+msgstr ""
+
+#: src/ui/pages/welcome.blp:5
+msgid "Welcome"
+msgstr ""
+
+#: src/ui/pages/welcome.blp:16
+msgid "Welcome to Nocturne"
+msgstr ""
+
+#: src/ui/pages/welcome.blp:17
+msgid "Select an instance type to get started"
+msgstr ""
+
+#: src/ui/playing/control_page.blp:5
+msgid "Playing"
+msgstr ""
+
+#: src/ui/playing/control_page.blp:75
+msgid "Visit current radio homepage"
+msgstr ""
+
+#: src/ui/playing/control_page.blp:157 src/ui/playing/footer.blp:99
+msgid "Previous"
+msgstr ""
+
+#: src/ui/playing/control_page.blp:201 src/ui/playing/footer.blp:143
+msgid "Next"
+msgstr ""
+
+#: src/ui/playing/control_page.blp:221
+msgid "Rate"
+msgstr ""
+
+#: src/ui/playing/control_page.blp:277
+msgid "Star"
+msgstr ""
+
+#: src/ui/playing/control_page.blp:284
+msgid "Toggle Sidebar"
+msgstr ""
+
+#: src/ui/playing/cover_art.blp:35
+msgid "Audio"
+msgstr ""
+
+#: src/ui/playing/cover_art.blp:43 src/ui/song/details_dialog.blp:34
+msgid "Song Cover"
+msgstr ""
+
+#: src/ui/playing/cover_art.blp:49 src/ui/playing/cover_art.blp:57
+msgid "Video"
+msgstr ""
+
+#: src/ui/playing/equalizer_page.blp:21
+msgid "Presets"
+msgstr ""
+
+#: src/ui/playing/equalizer_page.blp:26
+msgid "Flat"
+msgstr ""
+
+#: src/ui/playing/equalizer_page.blp:33
+msgid "Vocal Clarity"
+msgstr ""
+
+#: src/ui/playing/equalizer_page.blp:38
+msgid "Smooth Jazz"
+msgstr ""
+
+#: src/ui/playing/equalizer_page.blp:43
+msgid "Rock"
+msgstr ""
+
+#: src/ui/playing/equalizer_page.blp:48
+msgid "Classic"
+msgstr ""
+
+#: src/ui/playing/equalizer_page.blp:53
+msgid "Acoustic"
+msgstr ""
+
+#: src/ui/playing/footer.blp:12
+msgid "Current song progress indicator"
+msgstr ""
+
+#: src/ui/playing/footer.blp:45
+msgid "Current song cover art"
+msgstr ""
+
+#: src/ui/playing/lyrics_page.blp:25 src/ui/playing/lyrics_page.blp:85
+#: src/ui/playing/lyrics_page.blp:115 src/ui/playing/lyrics_page.blp:119
+#: src/ui/playing/lyrics_page.blp:132 src/ui/playing/lyrics_page.blp:136
+msgid "Go Back"
+msgstr ""
+
+#: src/ui/playing/lyrics_page.blp:67
+msgid "Lyrics Options"
+msgstr ""
+
+#: src/ui/playing/lyrics_page.blp:112
+msgid "No Lyrics Found"
+msgstr ""
+
+#: src/ui/playing/lyrics_page.blp:129
+msgid "Instrumental"
+msgstr ""
+
+#: src/ui/playing/lyrics_page.blp:154
+msgid "Not Downloaded"
+msgstr ""
+
+#: src/ui/playing/lyrics_page.blp:156
+msgid ""
+"The lyrics for this song have not been downloaded yet, they might be "
+"available for download"
+msgstr ""
+
+#: src/ui/playing/lyrics_page.blp:180 src/ui/playing/lyrics_page.blp:183
+msgid "Load Lyrics File"
+msgstr ""
+
+#: src/ui/playing/popout_window.blp:5
+msgid "Pop-out Window"
+msgstr ""
+
+#: src/ui/playing/popout_window.blp:67 src/ui/song/details_dialog.blp:5
+#: src/ui/window.blp:206
+msgid "Song Details"
+msgstr ""
+
+#: src/ui/playing/popout_window.blp:87 src/ui/window.blp:172
+#: src/ui/window.blp:228
+msgid "Queue"
+msgstr ""
+
+#: src/ui/playing/popout_window.blp:99 src/ui/window.blp:188
+#: src/ui/window.blp:240
+msgid "Equalizer"
+msgstr ""
+
+#: src/ui/playing/queue_page.blp:20
+msgid "Generating Next Queue"
+msgstr ""
+
+#: src/ui/playing/queue_page.blp:24
+msgid "Autoplay"
+msgstr ""
+
+#: src/ui/playing/queue_page.blp:25
+msgid "Generate a new queue when the current one ends"
+msgstr ""
+
+#: src/ui/playing/volume_button.blp:5
+msgid "Volume"
+msgstr ""
+
+#: src/ui/playing/volume_button.blp:12
+msgid "Speaker Mute"
+msgstr ""
+
+#: src/ui/playing/volume_button.blp:30
+msgid "Speaker Full Volume"
+msgstr ""
+
+#: src/ui/playlist/button.blp:41
+msgid "Show Playlist"
+msgstr ""
+
+#: src/ui/playlist/button.blp:53 src/ui/playlist/page.blp:50
+#: src/ui/playlist/row.blp:32 src/ui/playlist/selector_row.blp:24
+msgid "Playlist cover art"
+msgstr ""
+
+#: src/ui/playlist/button.blp:65
+msgid "Enter playlist page"
+msgstr ""
+
+#: src/ui/playlist/dialog.blp:6 src/ui/playlist/page.blp:5
+#: src/widgets/playlist/page.py:84
+msgid "Playlist"
+msgstr ""
+
+#: src/ui/playlist/dialog.blp:11
+msgid "Search (or create new playlist)"
+msgstr ""
+
+#: src/ui/playlist/dialog.blp:20
+msgid "Adding Music to Playlist"
+msgstr ""
+
+#: src/ui/playlist/dialog.blp:34
+msgid "Create New Playlist and Add Songs"
+msgstr ""
+
+#: src/ui/preferences.blp:7 src/ui/shortcuts-dialog.blp:6
+msgid "General"
+msgstr ""
+
+#: src/ui/preferences.blp:10
+msgid "Behavior"
+msgstr ""
+
+#: src/ui/preferences.blp:12
+msgid "Restore Queue on Launch"
+msgstr ""
+
+#: src/ui/preferences.blp:15
+msgid "Hide on Close"
+msgstr ""
+
+#: src/ui/preferences.blp:18
+msgid "Simulate Word by Word Lyrics"
+msgstr ""
+
+#: src/ui/preferences.blp:19
+msgid "Used when only line by line lyrics are available"
+msgstr ""
+
+#: src/ui/preferences.blp:22
+msgid "Auto Download Lyrics"
+msgstr ""
+
+#: src/ui/preferences.blp:23
+msgid "Used when the current instance does not provide lyrics"
+msgstr ""
+
+#: src/ui/preferences.blp:26
+msgid "Use Track and Album Gain"
+msgstr ""
+
+#: src/ui/preferences.blp:27
+msgid "Adjust the volume based on gain metadata"
+msgstr ""
+
+#: src/ui/preferences.blp:30
+msgid "Default Page on Login"
+msgstr ""
+
+#: src/ui/preferences.blp:35
+msgid "Maximum Bitrate"
+msgstr ""
+
+#: src/ui/preferences.blp:41
+msgid "Gnome Search"
+msgstr ""
+
+#: src/ui/preferences.blp:42
+msgid ""
+"Search for your music directly from the system search bar while Nocturne is "
+"running. You can enable or disable this feature completely in System Settings"
+msgstr ""
+
+#: src/ui/preferences.blp:45
+msgid "Include Artists"
+msgstr ""
+
+#: src/ui/preferences.blp:48
+msgid "Include Albums"
+msgstr ""
+
+#: src/ui/preferences.blp:51
+msgid "Include Songs"
+msgstr ""
+
+#: src/ui/preferences.blp:54
+msgid "Include Playlists"
+msgstr ""
+
+#: src/ui/preferences.blp:58
+msgid "Session"
+msgstr ""
+
+#: src/ui/preferences.blp:61
+msgid "Discord Rich Presence"
+msgstr ""
+
+#: src/ui/preferences.blp:62
+msgid "Share the currently playing song on Discord"
+msgstr ""
+
+#: src/ui/preferences.blp:66
+msgid "Share Cover Art With Discord"
+msgstr ""
+
+#: src/ui/preferences.blp:67
+msgid ""
+"If the instance is not reachable by Discord servers, CoverArtArchive will be "
+"used instead"
+msgstr ""
+
+#: src/ui/preferences.blp:73
+msgid "ListenBrainz Link"
+msgstr ""
+
+#: src/ui/preferences.blp:74
+msgid "Keep track of your playback history"
+msgstr ""
+
+#: src/ui/preferences.blp:80 src/ui/preferences.blp:81
+msgid "Link"
+msgstr ""
+
+#: src/ui/preferences.blp:89 src/ui/preferences.blp:90
+msgid "Unlink"
+msgstr ""
+
+#: src/ui/preferences.blp:102
+msgid "User"
+msgstr ""
+
+#: src/ui/preferences.blp:122
+msgid "Delete Image Cache"
+msgstr ""
+
+#: src/ui/preferences.blp:129
+msgid "Logout"
+msgstr ""
+
+#: src/ui/preferences.blp:139
+msgid "Customization"
+msgstr ""
+
+#: src/ui/preferences.blp:142
+msgid "Interface"
+msgstr ""
+
+#: src/ui/preferences.blp:144
+msgid "Show Context Button in Rows"
+msgstr ""
+
+#: src/ui/preferences.blp:145
+msgid "The menu can also be shown by right clicking / long pressing"
+msgstr ""
+
+#: src/ui/preferences.blp:148
+msgid "Show Labels in Buttons of Pages"
+msgstr ""
+
+#: src/ui/preferences.blp:151
+msgid "Show Progressbar in Player Footer"
+msgstr ""
+
+#: src/ui/preferences.blp:154
+msgid "Make Background Translucent in Player"
+msgstr ""
+
+#: src/ui/preferences.blp:157
+msgid "Use Sidebar Player When Possible"
+msgstr ""
+
+#: src/ui/preferences.blp:158
+msgid "Sidebar player is only available when the window is wide enough"
+msgstr ""
+
+#: src/ui/preferences.blp:161
+msgid "Show Pan Buttons on Carousels"
+msgstr ""
+
+#: src/ui/preferences.blp:162
+msgid "Only visible when a carousel has 5 or more items"
+msgstr ""
+
+#: src/ui/preferences.blp:165
+msgid "Button Size"
+msgstr ""
+
+#: src/ui/preferences.blp:166
+msgid "Affects albums, artists, playlists and songs"
+msgstr ""
+
+#: src/ui/preferences.blp:172 src/ui/preferences.blp:173
+msgid "Small"
+msgstr ""
+
+#: src/ui/preferences.blp:177 src/ui/preferences.blp:178
+msgid "Big"
+msgstr ""
+
+#: src/ui/preferences.blp:186
+msgid "Dynamic Background"
+msgstr ""
+
+#: src/ui/preferences.blp:187
+msgid "Background generated based on the album art of the current song"
+msgstr ""
+
+#: src/ui/preferences.blp:190
+msgid "Use in Main Window"
+msgstr ""
+
+#: src/ui/preferences.blp:196 src/ui/preferences.blp:197
+#: src/ui/preferences.blp:220 src/ui/preferences.blp:221
+#: src/ui/preferences.blp:244 src/ui/preferences.blp:245
+msgid "Off"
+msgstr ""
+
+#: src/ui/preferences.blp:201 src/ui/preferences.blp:202
+#: src/ui/preferences.blp:225 src/ui/preferences.blp:226
+#: src/ui/preferences.blp:249 src/ui/preferences.blp:250
+msgid "Gradient"
+msgstr ""
+
+#: src/ui/preferences.blp:206 src/ui/preferences.blp:207
+#: src/ui/preferences.blp:230 src/ui/preferences.blp:231
+#: src/ui/preferences.blp:254 src/ui/preferences.blp:255
+msgid "Blur"
+msgstr ""
+
+#: src/ui/preferences.blp:214
+msgid "Use in Player"
+msgstr ""
+
+#: src/ui/preferences.blp:238
+msgid "Use in Pop-out Window"
+msgstr ""
+
+#: src/ui/preferences.blp:262
+msgid "Use as Accent Color"
+msgstr ""
+
+#: src/ui/preferences.blp:267
+msgid "Homepage"
+msgstr ""
+
+#: src/ui/preferences.blp:268
+msgid "Reload homepage to see changes"
+msgstr ""
+
+#: src/ui/preferences.blp:304
+msgid "Sidebar"
+msgstr ""
+
+#: src/ui/preferences.blp:308
+msgid "Visualizer"
+msgstr ""
+
+#: src/ui/preferences.blp:312 src/ui/window.blp:257
+msgid "Preferences"
+msgstr ""
+
+#: src/ui/preferences.blp:314
+msgid "Show Visualizer in Player"
+msgstr ""
+
+#: src/ui/preferences.blp:315
+msgid "Show an audio spectrum visualizer on top of the album art in the player"
+msgstr ""
+
+#: src/ui/preferences.blp:320
+msgid "Appearance"
+msgstr ""
+
+#: src/ui/preferences.blp:324
+msgid "Number of Bars"
+msgstr ""
+
+#: src/ui/preferences.blp:335
+msgid "Visualizer Type"
+msgstr ""
+
+#: src/ui/preferences.blp:341 src/ui/preferences.blp:342
+msgid "Wave"
+msgstr ""
+
+#: src/ui/preferences.blp:346 src/ui/preferences.blp:347
+msgid "Bars"
+msgstr ""
+
+#: src/ui/preferences.blp:351 src/ui/preferences.blp:352
+msgid "Particles"
+msgstr ""
+
+#: src/ui/preferences.blp:359
+msgid "Fill Mode"
+msgstr ""
+
+#: src/ui/preferences.blp:365 src/ui/preferences.blp:366
+msgid "Solid"
+msgstr ""
+
+#: src/ui/preferences.blp:370 src/ui/preferences.blp:371
+msgid "Translucent"
+msgstr ""
+
+#: src/ui/preferences.blp:375 src/ui/preferences.blp:376
+msgid "Border"
+msgstr ""
+
+#: src/ui/preferences.blp:384
+msgid "Color"
+msgstr ""
+
+#: src/ui/preferences.blp:388
+msgid "Use Dynamic Color"
+msgstr ""
+
+#: src/ui/preferences.blp:391
+msgid "Invert Color"
+msgstr ""
+
+#: src/ui/preferences.blp:395
+msgid "Manual Color"
+msgstr ""
+
+#: src/ui/preferences.blp:401
+msgid "Visualizer Color"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:12
+msgid "Show Shortcuts"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:16
+msgid "Show Preferences"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:20
+msgid "Quit"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:27
+msgid "Toggle Playback"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:31
+msgid "Next Song"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:35
+msgid "Previous Song"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:39
+msgid "Raise Volume"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:43
+msgid "Lower Volume"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:48
+msgid "Window"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:50 src/ui/window.blp:267
+#: src/widgets/playing/popout_window.py:48
+msgid "Toggle Fullscreen"
+msgstr ""
+
+#: src/ui/shortcuts-dialog.blp:54 src/ui/window.blp:262
+msgid "Open Pop-Out Window"
+msgstr ""
+
+#: src/ui/song/button.blp:31 src/ui/song/small_row.blp:37
+msgid "Song cover art"
+msgstr ""
+
+#: src/ui/song/button.blp:45
+msgid "Play Indicator"
+msgstr ""
+
+#: src/ui/song/queue.blp:47 src/ui/song/queue.blp:49
+msgid "Select All"
+msgstr ""
+
+#: src/ui/song/row.blp:44
+msgid "Drag icon"
+msgstr ""
+
+#: src/ui/song/row.blp:142
+msgid "Selection box"
+msgstr ""
+
+#: src/ui/window.blp:91
+msgid "Play Random Queue"
+msgstr ""
+
+#: src/ui/window.blp:99
+msgid "Menu"
+msgstr ""
+
+#: src/ui/window.blp:127
+msgid "Random Albums"
+msgstr ""
+
+#: src/ui/window.blp:131
+msgid "Favorite Albums"
+msgstr ""
+
+#: src/ui/window.blp:135
+msgid "Newest Albums"
+msgstr ""
+
+#: src/ui/window.blp:139
+msgid "Recent Albums"
+msgstr ""
+
+#: src/ui/window.blp:143
+msgid "Frequent Albums"
+msgstr ""
+
+#: src/ui/window.blp:166
+msgid "Player"
+msgstr ""
+
+#: src/ui/window.blp:272
+msgid "See Last Nocturne Playback"
+msgstr ""
+
+#: src/ui/window.blp:277
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: src/ui/window.blp:282
+msgid "About Nocturne"
+msgstr ""
+
+#: src/widgets/album/button.py:95 src/widgets/album/page.py:150
+#: src/widgets/artist/page.py:130 src/widgets/playing/control_page.py:194
+#: src/widgets/song/row.py:188
+msgid "Not Favorite"
+msgstr ""
+
+#: src/widgets/album/page.py:18
+#, python-brace-format
+msgid "Disc {}"
+msgstr ""
+
+#: src/widgets/artist/button.py:56 src/widgets/artist/row.py:46
+#, python-brace-format
+msgid "{} Album"
+msgid_plural "{} Albums"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/widgets/artist/page.py:48
+msgid "Top Songs"
+msgstr ""
+
+#: src/widgets/artist/page.py:58
+msgid "Related Artists"
+msgstr ""
+
+#: src/widgets/artist/page.py:113
+msgid "Author"
+msgstr ""
+
+#: src/widgets/containers/context.py:50
+#, python-brace-format
+msgid "{} Stars"
+msgstr ""
+
+#: src/widgets/lyrics/dialog.py:54
+msgid "No Timestamp"
+msgstr ""
+
+#: src/widgets/pages/login.py:52 src/widgets/pages/login.py:115
+msgid "Running"
+msgstr ""
+
+#: src/widgets/pages/login.py:86
+msgid "Extra Menu"
+msgstr ""
+
+#: src/widgets/pages/login.py:104 src/widgets/pages/setup.py:83
+msgid "Music Library"
+msgstr ""
+
+#: src/widgets/pages/login.py:114
+msgid "Restarted"
+msgstr ""
+
+#: src/widgets/pages/login.py:153
+msgid "Quick Connect"
+msgstr ""
+
+#: src/widgets/pages/login.py:154
+msgid "Error getting code"
+msgstr ""
+
+#: src/widgets/pages/login.py:156
+msgid "Quick Connect Page"
+msgstr ""
+
+#: src/widgets/pages/playback.py:29
+#, python-brace-format
+msgid "Nocturne Playback ~ {}"
+msgstr ""
+
+#: src/widgets/pages/playback.py:48 src/widgets/pages/playback.py:57
+#, python-brace-format
+msgid "{} Plays"
+msgstr ""
+
+#: src/widgets/pages/setup.py:70
+msgid "Installing"
+msgstr ""
+
+#: src/widgets/pages/welcome.py:20 src/widgets/pages/welcome.py:22
+msgid "Integration"
+msgstr ""
+
+#: src/widgets/playing/lyrics_page.py:246
+msgid "LRC File"
+msgstr ""
+
+#: src/widgets/playing/player.py:621
+msgid "Warning: Song changed but volume is set to 0"
+msgstr ""
+
+#: src/widgets/playlist/button.py:63 src/widgets/playlist/page.py:116
+#: src/widgets/playlist/row.py:47 src/widgets/playlist/selector_row.py:36
+#, python-brace-format
+msgid "{} Song"
+msgid_plural "{} Songs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/widgets/playlist/dialog.py:55
+msgid "New Playlist"
+msgstr ""
+
+#: src/widgets/playlist/selector_row.py:33
+#, python-brace-format
+msgid "Add Songs to '{}'"
+msgstr ""
+
+#: src/widgets/song/details_dialog.py:22
+msgid "Yes"
+msgstr ""
+
+#: src/widgets/song/details_dialog.py:22
+msgid "No"
+msgstr ""
+
+#: src/widgets/song/details_dialog.py:27
+msgid "Not Found"
+msgstr ""
+
+#: src/widgets/song/row.py:147 src/widgets/song/row.py:152
+msgid "Multiple Artists"
+msgstr ""
+
+#: src/window.py:214
+#, python-brace-format
+msgid "Your Playback queue for {} is available!"
+msgstr ""
+
+#: src/window.py:216
+msgid "Show"
+msgstr ""
+
+#: src/window.py:217
+msgid "Later"
+msgstr ""


### PR DESCRIPTION
# Add Brazilian Portuguese (`pt_BR`) localization for Nocturne

### Motivation

Brazilian Portuguese was not previously available as a supported language. This PR adds a complete translation, allowing Brazilian Portuguese users to use Nocturne in their native language.

### Changes

- Add `po/pt_BR.po`
- Register `pt_BR` in `po/LINGUAS`
- Translate all current translatable strings

### Testing

The translation was validated with the following commands:

- `msgattrib --untranslated po/pt_BR.po`
- `msgfmt --check po/pt_BR.po`
- `msgfmt --statistics po/pt_BR.po`

Verified that the translation compiles without errors and that no untranslated strings remain.

### Related Issues

Closes #239

### Checklist

- [x] Code reviewed
- [x] Translation validated with `msgfmt`
- [ ] Documentation updated (not applicable)
- [x] No merge conflicts