### PR TITLE
Add device identifier to Jellyfin auth header

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,6 +1,6 @@
 # constants.py
 
-import os, subprocess, json, shutil
+import os, subprocess, json, shutil, uuid
 from tinytag import TinyTag
 
 CLI_ARGUMENTS = {
@@ -219,6 +219,34 @@ DOWNLOAD_MIME_MAP = {
 
 # Fallback only used if the system does not have a keyring
 FALLBACK_PASSWORD_PATH = os.path.join(CONFIG_DIR, 'pass.txt')
+
+# Retrieves device ID or generates a UUID if device ID not found
+# Used for Jellyfin session tracking
+def get_device_id():
+    device_id = None
+    if IN_FLATPAK:
+        try:
+            from pydbus import SessionBus
+            bus = SessionBus()
+            flatpak_portal = bus.get("org.freedesktop.portal.Flatpak", "/org/freedesktop/portal/Flatpak")
+            device_id = flatpak_portal.GetMachineId().strip()
+        except Exception as e:
+            pass
+    else:
+        for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"]:
+            if os.path.exists(path):
+                with open(path, "r") as f:
+                    device_id = f.read().strip()
+    if not device_id: #generate UUID as fallback
+        fallback_path = os.path.join(CONFIG_DIR, "device_id")
+        if os.path.exists(fallback_path):
+            with open(fallback_path, "r") as f:
+                device_id = f.read().strip()
+        else:
+            device_id = str(uuid.uuid4())
+            with open(fallback_path, "w") as f:
+                f.write(device_id)
+    return device_id
 
 BASE_NAVIDROME_DIR = os.path.join(DATA_DIR, "navidrome")
 os.makedirs(BASE_NAVIDROME_DIR, exist_ok=True)

--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -3,7 +3,7 @@
 from gi.repository import GLib, GObject, Gdk, Gio
 from . import secret, models, local, sql_instance
 from .base import Base
-from ..constants import DOWNLOAD_QUEUE_DIR, DOWNLOADS_DIR, DOWNLOAD_MIME_MAP
+from ..constants import DOWNLOAD_QUEUE_DIR, DOWNLOADS_DIR, DOWNLOAD_MIME_MAP, get_nocturne_version, get_device_id
 import os, platform, logging
 from urllib.parse import urlencode
 
@@ -34,14 +34,16 @@ class Jellyfin(Base):
         }
     }
 
-    AUTH_HEADER = 'MediaBrowser Client="Nocturne", Device="{}", DeviceId="{}", Version="1.0.0"'.format(platform.node(), str(abs(hash(platform.node()))))
-
     url = GObject.Property(type=str, default="http://127.0.0.1:8096")
 
     # Loaded by API
     accessToken = GObject.Property(type=str)
     userId = GObject.Property(type=str)
     libraryId = GObject.Property(type=str)
+
+    @property
+    def AUTH_HEADER(self) -> str:
+        return 'MediaBrowser Client="Nocturne", Device="{}", DeviceId="{}", Version="{}"'.format(platform.node(), get_device_id(), get_nocturne_version())
 
     def get_base_header(self) -> dict:
         headers = {


### PR DESCRIPTION
This PR passes a consistent device ID to the Jellyfin instance in the auth header. This prevents Jellyfin from generating a new device profile each time a user logs in, while also allowing for playback session reporting in the future (PR incoming when I can make my code for it a little less hideous). I put the `get_device_id` function in `constants.py` in case other integrations could find  a consistent device identifier useful. _Note: If users have chosen to obfuscate their device ID for privacy reasons, it'll fall back to generating a unique persistent UUID instead._