### PR TITLE
Fix internet radio metadata

### DIFF
--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -956,6 +956,7 @@ class Jellyfin(Base):
                 self.loaded_models.get(radio.get("Id")).set_property("radioStreamUrl", raw_url)
 
                 id_list.append(radio.get("Id"))
+                self.threads.submit(self.updateCoverArt, radio.get("Id"))
         return id_list
 
     def createInternetRadioStation(self, name:str, radioStreamUrl:str) -> bool:

--- a/src/widgets/playing/control_page.py
+++ b/src/widgets/playing/control_page.py
@@ -149,7 +149,7 @@ class PlayingControlPage(Adw.NavigationPage):
             homepage_url = '{}://{}'.format(stream_url.scheme, stream_url.netloc)
         self.radio_homepage_el.set_tooltip_text(homepage_url)
         self.radio_homepage_el.set_action_target_value(GLib.Variant.new_string(homepage_url))
-        self.radio_homepage_el.get_child().set_label(urlparse(radioStreamUrl).netloc.capitalize())
+        self.radio_homepage_el.get_child().set_label(urlparse(radioStreamUrl).netloc)
 
     def update_artistId(self, artistId:str):
         if artistId:

--- a/src/widgets/playing/control_page.py
+++ b/src/widgets/playing/control_page.py
@@ -149,6 +149,7 @@ class PlayingControlPage(Adw.NavigationPage):
             homepage_url = '{}://{}'.format(stream_url.scheme, stream_url.netloc)
         self.radio_homepage_el.set_tooltip_text(homepage_url)
         self.radio_homepage_el.set_action_target_value(GLib.Variant.new_string(homepage_url))
+        self.radio_homepage_el.get_child().set_label(urlparse(radioStreamUrl).netloc.capitalize())
 
     def update_artistId(self, artistId:str):
         if artistId:
@@ -200,7 +201,6 @@ class PlayingControlPage(Adw.NavigationPage):
         self.title_el.set_tooltip_text(display_title)
 
     def display_artist_changed(self, display_artist:str):
-        self.radio_homepage_el.get_child().set_label(display_artist)
         self.artist_el.get_child().set_label(display_artist)
         self.artist_el.set_tooltip_text(display_artist)
 

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -74,7 +74,7 @@ class PlayerAdapter(MprisAdapter):
         return MetadataObj(
             album=song.get_property('album'),
             art_url=self.last_cover_art.get('url'),
-            artists=[urlparse(song.get_property('radioStreamUrl')).netloc.capitalize()] if song.get_property('radioStreamUrl') else ([a.get('name') for a in song.get_property('artists')] or [song.get_property('artist')]),
+            artists=[urlparse(song.get_property('radioStreamUrl')).netloc] if song.get_property('radioStreamUrl') else ([a.get('name') for a in song.get_property('artists')] or [song.get_property('artist')]),
             as_text=[song.get_property('title')],
             length=song.get_property('duration')*1000000,
             title=song.get_property('title'),

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -591,9 +591,7 @@ class Player(EventAdapter):
         integration.loaded_models.get('currentSong').set_property('displaySongTitle', title)
 
     def update_radioStreamUrl(self, radioStreamUrl:str):
-        if radioStreamUrl:
-            integration = get_current_integration()
-            integration.loaded_models.get('currentSong').set_property('displaySongArtist', urlparse(radioStreamUrl).netloc.capitalize())
+        pass #Maybe add the radio stream URL to the currentSong or something?
 
     def update_artists(self, artists:list):
         integration = get_current_integration()

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -485,22 +485,21 @@ class Player(EventAdapter):
                     self.discord_rpc.update()
 
     def handle_message_tag(self, bus, message):
-        if message.src == self.gst:
-            integration = get_current_integration()
-            if model := integration.loaded_models.get('currentSong'):
-                if song_model := integration.loaded_models.get(model.get_property('songId')):
-                    if song_model.get_property('radioStreamUrl'): # is radio
-                        if tag_list := message.parse_tag():
-                            success, title = tag_list.get_string(Gst.TAG_TITLE)
-                            if success and title and title != 'null':
-                                current_title = model.get_property('displaySongTitle')
-                                if current_title != title:
-                                    model.set_property('displaySongTitle', title)
-                            success, artist = tag_list.get_string(Gst.TAG_ARTIST)
-                            if success and artist and artist != 'null':
-                                current_artist = model.get_property('displaySongArtist')
-                                if current_artist != artist:
-                                    model.set_property('displaySongArtist', artist)
+        integration = get_current_integration()
+        if model := integration.loaded_models.get('currentSong'):
+            if song_model := integration.loaded_models.get(model.get_property('songId')):
+                if song_model.get_property('radioStreamUrl'): # is radio
+                    if tag_list := message.parse_tag():
+                        success, title = tag_list.get_string(Gst.TAG_TITLE)
+                        if success and title and title != 'null':
+                            current_title = model.get_property('displaySongTitle')
+                            if current_title != title:
+                                model.set_property('displaySongTitle', title)
+                        success, artist = tag_list.get_string(Gst.TAG_ARTIST)
+                        if success and artist and artist != 'null':
+                            current_artist = model.get_property('displaySongArtist')
+                            if current_artist != artist:
+                                model.set_property('displaySongArtist', artist)
 
     def update_stream_progress(self):
         if integration := get_current_integration():

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -71,13 +71,27 @@ class PlayerAdapter(MprisAdapter):
             self.last_cover_art['id'] = song.get_property('id')
             self.last_cover_art['url'] = integration.getCoverArtUrl(song.get_property('id'))
 
+        if song.get_property('radioStreamUrl'):
+            if not (title := current_song_model.get_property("displaySongTitle")):
+                title = song.get_property('title')
+            if not (artist := current_song_model.get_property("displaySongArtist")):
+                artist = song.get_property('title')
+            if artist == title: #fall back to stream URL for artist so MPRIS widgets don't show duplicate labels
+                artist = urlparse(song.get_property('radioStreamUrl')).netloc
+            artists = [artist]
+            album = song.get_property('title')
+        else:
+            album = song.get_property('album')
+            artists = ([a.get('name') for a in song.get_property('artists')] or [song.get_property('artist')])
+            title = song.get_property('title')
+
         return MetadataObj(
-            album=song.get_property('album'),
+            album=album,
             art_url=self.last_cover_art.get('url'),
-            artists=[urlparse(song.get_property('radioStreamUrl')).netloc] if song.get_property('radioStreamUrl') else ([a.get('name') for a in song.get_property('artists')] or [song.get_property('artist')]),
+            artists=artists,
             as_text=[song.get_property('title')],
             length=song.get_property('duration')*1000000,
-            title=song.get_property('title'),
+            title=title,
             track_id='/com/jeffser/Nocturne/track/{}'.format(song.get_property('id')),
             track_number=0
         )
@@ -490,16 +504,18 @@ class Player(EventAdapter):
             if song_model := integration.loaded_models.get(model.get_property('songId')):
                 if song_model.get_property('radioStreamUrl'): # is radio
                     if tag_list := message.parse_tag():
-                        success, title = tag_list.get_string(Gst.TAG_TITLE)
-                        if success and title and title != 'null':
+                        success_title, title = tag_list.get_string(Gst.TAG_TITLE)
+                        if success_title and title and title != 'null':
                             current_title = model.get_property('displaySongTitle')
                             if current_title != title:
-                                model.set_property('displaySongTitle', title)
-                        success, artist = tag_list.get_string(Gst.TAG_ARTIST)
-                        if success and artist and artist != 'null':
+                                model.set_property('displaySongTitle', title.strip())
+                        success_artist, artist = tag_list.get_string(Gst.TAG_ARTIST)
+                        if success_artist and artist and artist != 'null':
                             current_artist = model.get_property('displaySongArtist')
                             if current_artist != artist:
-                                model.set_property('displaySongArtist', artist)
+                                model.set_property('displaySongArtist', artist.strip())
+                        if success_title or success_artist:
+                            self.emit_changes(self.mpris.player, changes=['Metadata', 'PlaybackStatus'])
 
     def update_stream_progress(self):
         if integration := get_current_integration():

--- a/src/widgets/song/row.py
+++ b/src/widgets/song/row.py
@@ -197,7 +197,7 @@ class SongRow(Adw.ActionRow):
                 action_target = GLib.Variant.new_string(homepage_url),
                 child = Gtk.Label(
                     ellipsize=Pango.EllipsizeMode.END,
-                    label=urlparse(homepage_url).netloc.capitalize(),
+                    label=urlparse(homepage_url).netloc,
                     css_classes=['subtitle']
                 ),
                 css_classes = ['p0', 'flat'],


### PR DESCRIPTION
### Summary
This PR addresses a few issues that were preventing the radio station metadata from being applied to the player window and adds an event to pass the metadata to MPRIS. 

### Changes
- Fetch the coverArt for the radio station in the Jellyfin integration because I completely forgot to add this back when I changed the Jellyfin API around-- whoops. 🫠
- The `handle_message_tag` function in `player.py` was checking if the message source was from `self.gst`, but the playbin object isn't actually the source of that bus message so it was always returning false. It should be safe to remove that check since Nocturne only uses one active playbin and the function logic dismisses messages without tags anyway.
- `display_artist_changed` in `control_page.py` was overwriting the radio url label with an empty string, so I set the label in `update_radioStreamUrl` instead. As a result, `update_radioStreamUrl` in `player.py` doesn't really do anything anymore since currentSong doesn't store the stream URL and the UI doesn't go off of displaySongArtist for the URL anymore.
- MPRIS gets sent the radio stream metadata now. If there's no stream metadata, the title will be the station name and the artist will be the stream url like before so the labels don't look redundant in MPRIS widgets. If there is a title but no artist (as is typical with icy metadata), then the artist will be the station name and the stream URL isn't sent to MPRIS at all. I passed the station name for the album field since I didn't know what else to pass for it and it's a good backup for HTTP and HLS streams that do have a title and artist.
- I removed the .capitalize() function on the radio stream url. Most stream urls have multiple subdomains and capitalizing the netloc string looked a little off to me. It's 100% a personal preference though, please feel free to revert it if you liked it better before. 😅