### PR TITLE
Add a favorite artists page

### DIFF
--- a/data/com.jeffser.Nocturne.gschema.xml
+++ b/data/com.jeffser.Nocturne.gschema.xml
@@ -196,7 +196,16 @@
 	  <key name="last-playback-checked" type="s">
 	    <default>''</default>
 	  </key>
-	  <key name="default-view-mode" type="s">
+	  <key name="default-view-mode-artists" type="s">
+	    <default>'grid'</default>
+	  </key>
+	  <key name="default-view-mode-albums" type="s">
+	    <default>'grid'</default>
+	  </key>
+	  <key name="default-view-mode-songs" type="s">
+	    <default>'list'</default>
+	  </key>
+	  <key name="default-view-mode-playlists" type="s">
 	    <default>'list'</default>
 	  </key>
 	</schema>

--- a/src/constants.py
+++ b/src/constants.py
@@ -396,11 +396,6 @@ SIDEBAR_MENU = [
                 'title': _("Home"),
                 'icon-name': "user-home-symbolic",
                 'page-tag': 'home'
-            },
-            { # Item
-                'title': _("Artists"),
-                'icon-name': "music-artist-symbolic",
-                'page-tag': 'artists'
             }
         ]
     },
@@ -436,6 +431,21 @@ SIDEBAR_MENU = [
                 'title': _("Most Played"),
                 'icon-name': "media-playlist-repeat-symbolic",
                 'page-tag': 'albums-frequent'
+            }
+        ]
+    },
+    { # Section
+        'title': _("Artists"),
+        'items': [
+            { # Item
+                'title': _("All"),
+                'icon-name': "music-artist-symbolic",
+                'page-tag': 'artists'
+            },
+            { # Item
+                'title': _("Favorites"),
+                'icon-name': "heart-filled-symbolic",
+                'page-tag': 'artists-starred'
             }
         ]
     },

--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -322,9 +322,9 @@ class Base(GObject.Object):
         print('WARNING', 'getPlaylists', 'not implemented')
         return []
 
-    def getStarredSongs(self) -> list:
-        # returns a list of IDs of songs
-        print('WARNING', 'getStarredSongs', 'not implemented')
+    def getStarred(self, item_type:str) -> list:
+        # returns a list of IDs of items of a given type
+        print('WARNING', 'getStarred', 'not implemented')
         return []
 
     def verifyArtist(self, model_id:str, force_update:bool=False, use_threading:bool=True):

--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -358,22 +358,43 @@ class Jellyfin(Base):
         self.__bulk_verify("Playlist", playlists)
         return [playlist.get("Id") for playlist in playlists]
 
-    def getStarredSongs(self) -> list:
-        song_list = []
-        songs = self.make_request(
-            action="Users/{userId}/Items",
-            mode="GET",
-            params={
-                "IncludeItemTypes": "Audio",
+    def getStarred(self, item_type:str) -> list:
+        check = {
+            "artist": "MusicArtist",
+            "album": "MusicAlbum",
+            "song": "Audio",
+            "playlist": "Playlist"
+        }
+        if item_type == 'artist':
+            items = self.make_request(
+                action='Artists/AlbumArtists',
+                mode="GET",
+                params={
+                    "userId": self.get_property("userId"),
+                    "parentId": self.get_property("libraryId"),
+                    "Recursive": "true",
+                    "Filters": "isFavorite"
+                }
+            ).get('Items', [])
+        else:
+            params = {
+                "IncludeItemTypes": check[item_type],
                 "Recursive": "true",
                 "Fields": "Id",
-                "Filters": "IsFavorite",
-                "ParentId": self.get_property("libraryId")
+                "Filters": "IsFavorite"
             }
-        ).get("Items", [])
+            if item_type != 'playlist':
+                params["ParentId"] = self.get_property("libraryId")
 
-        self.__bulk_verify("Audio", songs)
-        return [song.get("Id") for song in songs]
+            items = self.make_request(
+                action="Users/{userId}/Items",
+                mode="GET",
+                params=params
+            ).get("Items", [])
+
+        self.__bulk_verify(check[item_type], items)
+        return [item.get("Id") for item in items]
+
 
     def verifyArtist(self, model_id:str, force_update:bool=False, use_threading:bool=True, artist_object:models.Artist=None, lite:bool=False):
         def run():

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -270,12 +270,13 @@ class Local(Base):
         self.load_playlists()
         return [model_id for model_id in list(self.loaded_models) if model_id.startswith('PLAYLIST:')]
 
-    def getStarredSongs(self) -> list:
+    def getStarred(self, item_type:str) -> list:
         conn, cursor = sql_instance.get_connection(self)
         cursor.execute("SELECT id FROM stars")
         star_list = [str(r[0]) for r in cursor.fetchall()]
         conn.close()
-        return [song_id for song_id in star_list if song_id.startswith("SONG:") and song_id in self.loaded_models]
+        query = f"{item_type.upper()}:"
+        return [item_id for item_id in star_list if item_id.startswith(query) and item_id in self.loaded_models]
 
     def verifyArtist(self, model_id:str, force_update:bool=False, use_threading:bool=True):
         threading.Thread(target=self.updateCoverArt, args=(model_id,), daemon=True).start()

--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -236,9 +236,9 @@ class Navidrome(Base):
                     self.loaded_models[new_id] = models.Playlist(**playlist_dict)
         return playlist_ids
 
-    def getStarredSongs(self) -> list:
-        songs = self.make_request('getStarred2').get('starred2', {}).get('song', [])
-        return [song.get('id') for song in songs]
+    def getStarred(self, item_type:str) -> list:
+        items = self.make_request('getStarred2').get('starred2', {}).get(item_type, [])
+        return [item.get('id') for item in items]
 
     def verifyArtist(self, model_id:str, force_update:bool=False, use_threading:bool=True):
         def update():

--- a/src/ui/pages/songs_starred.blp
+++ b/src/ui/pages/songs_starred.blp
@@ -91,7 +91,7 @@ template $NocturneSongsStarredPage: Adw.NavigationPage {
       }
       Gtk.StackPage {
         name: "no-content";
-        child: Adw.StatusPage {
+        child: Adw.StatusPage failed_status_el {
           icon-name: "sad-computer-symbolic";
           title: _("No Songs Found");
         };

--- a/src/ui/pages/songs_starred.blp
+++ b/src/ui/pages/songs_starred.blp
@@ -25,7 +25,7 @@ template $NocturneSongsStarredPage: Adw.NavigationPage {
       title-widget: Gtk.SearchEntry search_entry_el {
         hexpand: true;
         key-capture-widget: main_stack;
-        placeholder-text: _("Favorite Songs");
+        placeholder-text: bind template.title;
         search-changed => $on_search();
         accessibility {
           label: _("Search favorite songs");

--- a/src/ui/window.blp
+++ b/src/ui/window.blp
@@ -120,6 +120,10 @@ template $NocturneWindow: Adw.ApplicationWindow {
                 content: Adw.NavigationView main_navigationview {
                   $NocturneHomePage {}
                   $NocturneArtistsPage {}
+                  $NocturneSongsStarredPage {
+                    tag: "artists-starred";
+                    title:_("Favorite Artists");
+                  }
                   $NocturnePlaylistsPage {}
                   $NocturneSongsAllPage {}
                   $NocturneSongsStarredPage {}

--- a/src/ui/window.blp
+++ b/src/ui/window.blp
@@ -126,7 +126,10 @@ template $NocturneWindow: Adw.ApplicationWindow {
                   }
                   $NocturnePlaylistsPage {}
                   $NocturneSongsAllPage {}
-                  $NocturneSongsStarredPage {}
+                  $NocturneSongsStarredPage {
+                    tag: "songs-starred";
+                    title:_("Favorite Songs");
+                  }
                   $NocturneAlbumsAllPage {}
                   $NocturneRadiosPage {}
                   $NocturneAlbumsPage {

--- a/src/widgets/pages/albums_all.py
+++ b/src/widgets/pages/albums_all.py
@@ -24,7 +24,7 @@ class AlbumsAllPage(Adw.NavigationPage):
         super().__init__()
         self.settings = Gio.Settings(schema_id="com.jeffser.Nocturne")
         self.settings.bind(
-            "default-view-mode",
+            "default-view-mode-albums",
             self.toggle_group_el,
             "active-name",
             Gio.SettingsBindFlags.DEFAULT

--- a/src/widgets/pages/artists.py
+++ b/src/widgets/pages/artists.py
@@ -22,7 +22,7 @@ class ArtistsPage(Adw.NavigationPage):
     def __init__(self):
         super().__init__()
         Gio.Settings(schema_id="com.jeffser.Nocturne").bind(
-            "default-view-mode",
+            "default-view-mode-artists",
             self.toggle_group_el,
             "active-name",
             Gio.SettingsBindFlags.DEFAULT

--- a/src/widgets/pages/playlists.py
+++ b/src/widgets/pages/playlists.py
@@ -22,7 +22,7 @@ class PlaylistsPage(Adw.NavigationPage):
     def __init__(self):
         super().__init__()
         Gio.Settings(schema_id="com.jeffser.Nocturne").bind(
-            "default-view-mode",
+            "default-view-mode-playlists",
             self.toggle_group_el,
             "active-name",
             Gio.SettingsBindFlags.DEFAULT

--- a/src/widgets/pages/songs_all.py
+++ b/src/widgets/pages/songs_all.py
@@ -22,7 +22,7 @@ class SongsAllPage(Adw.NavigationPage):
     def __init__(self):
         super().__init__()
         Gio.Settings(schema_id="com.jeffser.Nocturne").bind(
-            "default-view-mode",
+            "default-view-mode-songs",
             self.toggle_group_el,
             "active-name",
             Gio.SettingsBindFlags.DEFAULT

--- a/src/widgets/pages/songs_starred.py
+++ b/src/widgets/pages/songs_starred.py
@@ -35,6 +35,13 @@ class SongsStarredPage(Adw.NavigationPage):
             Gio.SettingsBindFlags.DEFAULT
         )
 
+        if self.get_tag() == 'favorite-artists':
+            GLib.idle_add(self.search_entry_el.update_property(
+                [Gtk.AccessibleProperty.LABEL],
+                [_("Search favorite artists")]
+            ))
+            GLib.idle_add(self.failed_status_el.set_title(_("No Artists Found")))
+
     def search(self):
         if self.searching:
             return

--- a/src/widgets/pages/songs_starred.py
+++ b/src/widgets/pages/songs_starred.py
@@ -16,6 +16,7 @@ class SongsStarredPage(Adw.NavigationPage):
     main_stack = Gtk.Template.Child()
     scrolledwindow = Gtk.Template.Child()
     toggle_group_el = Gtk.Template.Child()
+    failed_status_el = Gtk.Template.Child()
     item_ids = []
     offset = 0
     searching = False
@@ -23,9 +24,12 @@ class SongsStarredPage(Adw.NavigationPage):
     def __init__(self):
         super().__init__()
         self.scrolledwindow.get_vadjustment().connect('notify::upper', lambda va, ud: GLib.timeout_add(1000, self.check_scrollbar, va))
+        self.connect("notify::tag", self.on_tag_assigned)
 
+    def on_tag_assigned(self, obj, pspec):
+        pref_string = f"default-view-mode-{self.get_tag().split('-')[0]}"
         Gio.Settings(schema_id="com.jeffser.Nocturne").bind(
-            "default-view-mode",
+            pref_string,
             self.toggle_group_el,
             "active-name",
             Gio.SettingsBindFlags.DEFAULT

--- a/src/widgets/pages/songs_starred.py
+++ b/src/widgets/pages/songs_starred.py
@@ -1,8 +1,9 @@
 # songs_starred.py
 
-from gi.repository import Gtk, Adw, GLib
+from gi.repository import Gtk, Adw, GLib, Gio
 from ...integrations import get_current_integration
 from ..song import SongRow, SongButton
+from ..artist import ArtistRow, ArtistButton
 import re, threading
 
 @Gtk.Template(resource_path='/com/jeffser/Nocturne/pages/songs_starred.ui')
@@ -14,13 +15,21 @@ class SongsStarredPage(Adw.NavigationPage):
     search_entry_el = Gtk.Template.Child()
     main_stack = Gtk.Template.Child()
     scrolledwindow = Gtk.Template.Child()
-    song_ids = []
+    toggle_group_el = Gtk.Template.Child()
+    item_ids = []
     offset = 0
     searching = False
 
     def __init__(self):
         super().__init__()
         self.scrolledwindow.get_vadjustment().connect('notify::upper', lambda va, ud: GLib.timeout_add(1000, self.check_scrollbar, va))
+
+        Gio.Settings(schema_id="com.jeffser.Nocturne").bind(
+            "default-view-mode",
+            self.toggle_group_el,
+            "active-name",
+            Gio.SettingsBindFlags.DEFAULT
+        )
 
     def search(self):
         if self.searching:
@@ -29,12 +38,16 @@ class SongsStarredPage(Adw.NavigationPage):
         integration = get_current_integration()
         ids_to_show = []
         if query := self.search_entry_el.get_text():
-            for song_id in self.song_ids:
-                if model := integration.loaded_models.get(song_id):
-                    if re.search(query, model.get_property('title') + model.get_property('artist'), re.IGNORECASE):
-                        ids_to_show.append(song_id)
+            for item_id in self.item_ids:
+                if model := integration.loaded_models.get(item_id):
+                    if 'songs' in self.get_tag():
+                        checker = model.get_property('title') + model.get_property('artist')
+                    elif 'artists' in self.get_tag():
+                        checker = model.get_property('name')
+                    if re.search(query, checker, re.IGNORECASE):
+                        ids_to_show.append(item_id)
         else:
-            ids_to_show = self.song_ids
+            ids_to_show = self.item_ids
 
         ids_to_show = ids_to_show[:self.offset+30]
         missing_ids = ids_to_show.copy()
@@ -44,9 +57,13 @@ class SongsStarredPage(Adw.NavigationPage):
             if widget.id in missing_ids:
                 missing_ids.remove(widget.id)
 
-        for song_id in missing_ids:
-            GLib.idle_add(self.list_el.list_el.append, SongRow(song_id))
-            GLib.idle_add(self.wrapbox_el.append, SongButton(song_id))
+        for item_id in missing_ids:
+            if 'songs' in self.get_tag():
+                GLib.idle_add(self.list_el.list_el.append, SongRow(item_id))
+                GLib.idle_add(self.wrapbox_el.append, SongButton(item_id))
+            elif 'artists' in self.get_tag():
+                GLib.idle_add(self.list_el.list_el.append, ArtistRow(item_id))
+                GLib.idle_add(self.wrapbox_el.append, ArtistButton(item_id))
         self.offset += 30
         GLib.idle_add(self.update_visibility)
         self.searching = False
@@ -61,7 +78,7 @@ class SongsStarredPage(Adw.NavigationPage):
         for el in list(self.wrapbox_el):
             self.wrapbox_el.remove(el)
         integration = get_current_integration()
-        self.song_ids = integration.getStarredSongs()
+        self.item_ids = integration.getStarred((self.get_tag().split('-')[0]).removesuffix("s"))
 
     def reload(self):
         GLib.idle_add(self.main_stack.set_visible_child_name, 'loading')
@@ -75,7 +92,7 @@ class SongsStarredPage(Adw.NavigationPage):
 
     @Gtk.Template.Callback()
     def scroll_edge_reached(self, scrolledwindow, pos):
-        if pos == Gtk.PositionType.BOTTOM and self.offset < len(self.song_ids):
+        if pos == Gtk.PositionType.BOTTOM and self.offset < len(self.item_ids):
             threading.Thread(target=self.search, daemon=True).start()
 
     def update_visibility(self):

--- a/src/widgets/pages/songs_starred.py
+++ b/src/widgets/pages/songs_starred.py
@@ -85,16 +85,19 @@ class SongsStarredPage(Adw.NavigationPage):
 
     def reset(self):
         self.offset = 0
-        self.list_el.list_el.remove_all()
+        GLib.idle_add(self.list_el.list_el.remove_all)
         for el in list(self.wrapbox_el):
-            self.wrapbox_el.remove(el)
+            GLib.idle_add(self.wrapbox_el.remove, el)
         integration = get_current_integration()
         self.item_ids = integration.getStarred((self.get_tag().split('-')[0]).removesuffix("s"))
 
     def reload(self):
         GLib.idle_add(self.main_stack.set_visible_child_name, 'loading')
-        GLib.idle_add(self.reset)
-        GLib.idle_add(self.search)
+
+        def run():
+            self.reset()
+            self.search()
+        threading.Thread(target=run, daemon=True).start()
 
     @Gtk.Template.Callback()
     def on_search(self, search_entry):


### PR DESCRIPTION
### Summary
This PR adds a favorite artists page to address #137. It re-uses the Favorite Songs page and just checks the page tag to determine if it should present favorite songs or favorite artists.

### Changes
- Adds a Favorite Artists page by reusing `songs-starred.py` and `songs-starred.blp`
- Moves the Artists into its own section of the sidebar with an 'All' and 'Favorites' pages.
- Changes the `getStarredSongs` functions in each integration to be a generalized `getStarred` function that lets you pick which type of starred object you want.
- Changes the default-view-mode Gio.Setting to instead have four settings, one for artists, albums, songs, and playlists, since often-times people have a display preference based on the content being shown.
- Moved some functions to a background thread in `songs-starred.py` to prevent the main thread from locking up.

### Testing
I tested `getStarred` thoroughly on the Jellyfin integration and I used the Navidrome demo site to test my changes to `getStarred` on the Navidrome integration and both seemed to work well (although the Navidrome demo site is a little slow and unreliable sometimes).

As for the local integration, I don't have a particularly robust local library nor a particularly great understanding of how the local integration works. I replaced the query on Line 278 `song_id.startswith("SONG:")` with a format string that takes in the `item_type` that passes it to the query with `f"{item_type.upper()}:"` and I'm not sure if that's the correct approach. Any feedback, changes, and testing help would be super appreciated!