### PR TITLE
Fix plaintext lyrics and Jellyfin lyrics formatting

### DIFF
--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -778,14 +778,17 @@ class Jellyfin(Base):
             if result.get('Lyrics', [{}])[0].get('Start'): # is lrc
                 lines = []
                 for line in result.get('Lyrics', []):
-                    lines.append({
-                        'content': line.get('Text'),
-                        'ms': line.get('Start') / 10000
-                    })
-                return True, {
-                    'type': 'lrc',
-                    'content': lines
-                }
+                    ms = line.get('Start') / 10000
+                    minutes = int(ms // 60000)
+                    seconds = int((ms % 60000) // 1000)
+                    centiseconds = int((ms % 1000) // 10)
+                    timestamp = f"[{minutes:02d}:{seconds:02d}.{centiseconds:02d}]"
+                    lines.append(f"{timestamp} {line.get('Text').strip()}")
+                if content := '\n'.join(lines):
+                    return True, {
+                        'type': 'lrc',
+                        'content': content
+                    }
             else:
                 text = '\n'.join([line.get('Text') for line in result.get('Lyrics', [])])
                 if text:

--- a/src/widgets/playing/lyrics_page.py
+++ b/src/widgets/playing/lyrics_page.py
@@ -131,7 +131,7 @@ class PlayingLyricsPage(Gtk.Stack):
 
         GLib.idle_add(self.set_visible_child_name, lyrics_type)
         if lyrics_type == 'plain':
-            GLib.idle_add(self.plain_label_el.set_label, content)
+            GLib.idle_add(self.plain_label_el.set_label, raw_content)
         elif lyrics_type == 'lrc':
             content = prepare_lrc(raw_content)
             GLib.idle_add(self.lrc_list_el.remove_all)


### PR DESCRIPTION
Fixes #253. 

### Changes
- Plaintext lyrics were being set with the undeclared `content` variable (used in the lrc lyrics block) instead of `raw_content` so it now passes `raw_content` instead.
- Jellyfin LRC lyrics were being parsed to the old millisecond format and returned as the wrong data type. It's been updated to the new timestamp format and fixed to return a string instead of a list for writing to the cache db.