### PR TITLE
Fix the search bar getting stuck on an old query

### DIFF
--- a/src/widgets/pages/albums_all.py
+++ b/src/widgets/pages/albums_all.py
@@ -47,15 +47,19 @@ class AlbumsAllPage(Adw.NavigationPage):
         if self.searching:
             return
         self.searching = True
-        query = self.search_entry.get_text()
         integration = get_current_integration()
         hide_singles = self.settings.get_value('hide-singles').unpack()
         self.skipped_albums = 0
-        search_results = integration.search(
-            query=query,
-            albumCount=30,
-            albumOffset=self.offset
-        )
+
+        query = self.search_entry.get_text()
+        query_check = ""
+        while True: #do-while loop if search entry changes while integration is loading
+            search_results = integration.search(query=query, albumCount=30, albumOffset=self.offset)
+            query_check = query
+            query = self.search_entry.get_text()
+            if query == query_check:
+                break
+
         for album_id in search_results.get('album'):
             should_skip = False
             if hide_singles:

--- a/src/widgets/pages/artists.py
+++ b/src/widgets/pages/artists.py
@@ -46,13 +46,17 @@ class ArtistsPage(Adw.NavigationPage):
         if self.searching:
             return
         self.searching = True
-        query = self.search_entry.get_text()
         integration = get_current_integration()
-        search_results = integration.search(
-            query=query,
-            artistCount=30,
-            artistOffset=self.offset
-        )
+
+        query = self.search_entry.get_text()
+        query_check = ""
+        while True: #do-while loop if search entry changes while integration is loading
+            search_results = integration.search(query=query, artistCount=30, artistOffset=self.offset)
+            query_check = query
+            query = self.search_entry.get_text()
+            if query == query_check:
+                break
+
         for artist_id in search_results.get('artist'):
             results_list = [row for row in list(self.list_el) if row.id == artist_id]
             if len(results_list) > 0:

--- a/src/widgets/pages/home.py
+++ b/src/widgets/pages/home.py
@@ -130,20 +130,26 @@ class HomePage(Adw.NavigationPage):
         GLib.idle_add(self.main_stack.set_visible_child_name, 'loading')
         if integration := get_current_integration():
             if query := self.search_entry.get_text():
-                search_results = integration.search(
-                    query=query,
-                    songCount=self.max_songs,
-                    artistCount=self.max_artists,
-                    albumCount=self.max_albums,
-                    playlistCount=self.max_playlists
-                )
+                query_check = ""
+                while True: #do-while loop if search entry changes while integration is loading
+                    search_results = integration.search(
+                        query=query,
+                        songCount=self.max_songs,
+                        artistCount=self.max_artists,
+                        albumCount=self.max_albums,
+                        playlistCount=self.max_playlists
+                    )
+                    query_check = query
+                    query = self.search_entry.get_text()
+                    if query == query_check:
+                        break
                 if self.settings.get_value('hide-singles').unpack():
                     if album_results := search_results.get('album'):
                         for albumId in album_results.copy():
                             if model := integration.loaded_models.get(albumId):
                                 if model.get_property('songCount') <= 1:
                                     search_results['album'].remove(albumId)
-            else:
+            if not query:
                 search_results = self.get_default_results()
             threading.Thread(
                 target=self.frequent_album_carousel.set_widgets,

--- a/src/widgets/pages/playlists.py
+++ b/src/widgets/pages/playlists.py
@@ -46,13 +46,17 @@ class PlaylistsPage(Adw.NavigationPage):
         if self.searching:
             return
         self.searching = True
-        query = self.search_entry.get_text()
         integration = get_current_integration()
-        search_results = integration.search(
-            query=query,
-            playlistCount=30,
-            playlistOffset=self.offset
-        )
+
+        query = self.search_entry.get_text()
+        query_check = ""
+        while True: #do-while loop if search entry changes while integration is loading
+            search_results = integration.search(query=query, playlistCount=30, playlistOffset=self.offset)
+            query_check = query
+            query = self.search_entry.get_text()
+            if query == query_check:
+                break
+
         for playlist_id in search_results.get('playlist'):
             results_list = [row for row in list(self.list_el) if row.id == playlist_id]
             if len(results_list) > 0:


### PR DESCRIPTION
### The Issue
The search function on the Home/Artist/All Albums/Playlists pages would get stuck. If users type into the search bar while the search function is waiting for the server to respond, the search function would simply `return` without launching a new search. If the user was typing, say, 'coldplay' it'd get stuck on 'co' and not re-search when they finished typing 'coldplay'.

### The Fix
I'm not sure if this is the best approach, but I wrapped the `integration.search()` function in (Python's best approximation of) a do-while loop. If the `integration.search()` function returns and the query has changed since it launched, it'll run the search function again with the new query.