### PR TITLE
Implement gapless playback

### DIFF
--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -255,6 +255,7 @@ class Player(EventAdapter):
         except:
             logger.warning("Video dependency not found")
         self.gst.connect("video-changed", self.video_changed)
+        self.gst.connect("about-to-finish", self.preload_next_track)
 
         self.bin = Gst.Bin.new("audio-filter-bin")
 
@@ -317,6 +318,7 @@ class Player(EventAdapter):
         self.bus.connect("message::state-changed", self.handle_message_state_changed)
         self.bus.connect("message::tag", self.handle_message_tag)
         self.bus.connect("message::element", self.handle_message_element)
+        self.bus.connect("message::stream-start", self.handle_stream_start)
 
         self.adapter = PlayerAdapter(self)
         self.mpris = Server("com.jeffser.Nocturne", adapter=self.adapter)
@@ -352,6 +354,9 @@ class Player(EventAdapter):
         integration.connect_to_model('currentSong', 'songId', lambda *_: self.discord_rpc.update())
         integration.connect_to_model('currentSong', 'displaySongTitle', lambda *_: self.discord_rpc.update())
         integration.connect_to_model('currentSong', 'displaySongArtist', lambda *_: self.discord_rpc.update())
+
+        # Track ID of song when it's preloaded
+        self.preloaded_id = ""
 
     def settings_volume_changed(self, settings, key):
         if not self.updating_volume:
@@ -520,6 +525,37 @@ class Player(EventAdapter):
                         if success_title or success_artist:
                             self.emit_changes(self.mpris.player, changes=['Metadata', 'PlaybackStatus'])
 
+    def get_next_queue_id(self):
+        integration = get_current_integration()
+        current_song = integration.loaded_models.get('currentSong')
+        id_list = [so.get_string() for so in current_song.get_property('queueModel')]
+
+        next_id = ""
+        if len(id_list) > 0:
+            mode = self.settings.get_value('playback-mode').unpack()
+            if mode == 'repeat-all':
+                try:
+                    next_index = id_list.index(current_song.songId) + 1
+                    next_id = id_list[next_index]
+                except IndexError:
+                    next_id = id_list[0]
+            elif mode == 'repeat-one':
+                next_id = current_song.songId
+            elif mode == 'consecutive':
+                try:
+                    next_index = id_list.index(current_song.songId) + 1
+                    next_id = id_list[next_index]
+                except IndexError:
+                    pass
+            return next_id
+
+    def preload_next_track(self, playbin):
+        integration = get_current_integration()
+        if next_id := self.get_next_queue_id():
+            stream_url = integration.get_stream_url(next_id)
+            self.gst.set_property('uri', stream_url)
+            self.preloaded_id = next_id
+
     def update_stream_progress(self):
         if integration := get_current_integration():
             if integration.loaded_models.get('currentSong').get_property('seeking'):
@@ -531,6 +567,10 @@ class Player(EventAdapter):
                 current_song.set_property('positionSeconds', seconds)
         return True
 
+    def handle_stream_start(self, bus, message):
+        if self.preloaded_id:
+            integration = get_current_integration()
+            integration.loaded_models.get('currentSong').set_property('songId', self.preloaded_id)
 
     def restore_play_queue(self):
         integration = get_current_integration()
@@ -642,8 +682,9 @@ class Player(EventAdapter):
                         ))
 
                 if stream_url := integration.get_stream_url(song_id):
-                    self.gst.set_state(Gst.State.READY)
-                    self.gst.set_property('uri', stream_url)
+                    if song_id != self.preloaded_id: #check for preloaded track
+                        self.gst.set_state(Gst.State.READY)
+                        self.gst.set_property('uri', stream_url)
                     if self.pause_next_change:
                         self.gst.set_state(Gst.State.PAUSED)
                         self.pause_next_change = False
@@ -661,4 +702,5 @@ class Player(EventAdapter):
                     self.gst.set_state(Gst.State.NULL)
         else:
             self.gst.set_state(Gst.State.NULL)
+        self.preloaded_id = ""
         gc.collect()


### PR DESCRIPTION
### Summary
Fixes #215 by implementing gapless playback.

### Changes to `player.py`
- Adds a `preload_next_track` function that is triggered by the GStreamer playbin's `about-to-finish` signal to assign the next song's URL to the playbin when the track is nearing completion instead of after.
- Adds a `preloaded_id` class variable that gets set only when a preloaded song is added to the playbin so `song_changed` doesn't attempt to overwrite the playbin URI.
- Adds a `handle_stream_start` function that is triggered by the GStreamer bus's `message::stream-start` signal which passes `self.preloaded_id` to the currentSong model once the new song's stream buffer is ready. As `message::eos` doesn't get triggered when there's a preloaded track (as it technically doesn't reach the end of the stream), the `handle_song_change_request` function doesn't get called when the song ends, so `handle_stream_start` picks up the slack for preloaded tracks.
- Adds a `get_next_queue_id` function to get the ID for the next song in the player queue. It's currently only called by the `preload_next_track` function, but it'll likely be more useful if I ever finish writing the Jellyfin playback reporting code I'm working on.