### PR TITLE
Fix favorites song loading crashes with gtk main thread safety

### DIFF
--- a/src/integrations/base.py
+++ b/src/integrations/base.py
@@ -222,9 +222,9 @@ class Base(GObject.Object):
         if model_id in self.loaded_models:
             connection_id = self.loaded_models.get(model_id).connect(
                 'notify::{}'.format(parameter),
-                lambda *_, p=parameter, mid=model_id, cb=callback: cb(self.loaded_models.get(mid).get_property(p))
+                lambda *_, p=parameter, mid=model_id, cb=callback: GLib.idle_add(cb, self.loaded_models.get(mid).get_property(p))
             )
-            callback(self.loaded_models.get(model_id).get_property(parameter))
+            GLib.idle_add(callback, self.loaded_models.get(model_id).get_property(parameter))
         return connection_id
 
     def save_cache_image(self, model_id:str, size:int, image_data:bytes):
@@ -643,6 +643,5 @@ class Base(GObject.Object):
         # link : str
         logger.warning('method not implemented')
         return {}
-
 
 

--- a/src/widgets/pages/starred.py
+++ b/src/widgets/pages/starred.py
@@ -71,11 +71,11 @@ class StarredPage(Adw.NavigationPage):
 
         for item_id in missing_ids:
             if 'songs' in self.get_tag():
-                GLib.idle_add(self.list_el.list_el.append, SongRow(item_id))
-                GLib.idle_add(self.wrapbox_el.append, SongButton(item_id))
+                GLib.idle_add(lambda item_id: self.list_el.list_el.append(SongRow(item_id)), item_id)
+                GLib.idle_add(lambda item_id: self.wrapbox_el.append(SongButton(item_id)), item_id)
             elif 'artists' in self.get_tag():
-                GLib.idle_add(self.list_el.list_el.append, ArtistRow(item_id))
-                GLib.idle_add(self.wrapbox_el.append, ArtistButton(item_id))
+                GLib.idle_add(lambda item_id: self.list_el.list_el.append(ArtistRow(item_id)), item_id)
+                GLib.idle_add(lambda item_id: self.wrapbox_el.append(ArtistButton(item_id)), item_id)
         self.offset += 30
         GLib.idle_add(self.update_visibility)
         self.searching = False


### PR DESCRIPTION
This is a small fix for #264 where the app intermittently crashes when loading favorite songs

This fix ensures all Favorites widgets and model-driven UI updates run on GTK’s main thread.

Previously, worker threads constructed GTK widgets and invoked callbacks that changed visibility and CSS state. This caused intermittent GTK state corruption and crashes. The fix dispatches widget construction and model callbacks through the GLib main loop.

With this change, the favorites list now loads consistently and I have not seen a crash.
Let me know if you think something needs to be changed.