### PR TITLE
Separate title and artist metadata for internet radio streams

### DIFF
--- a/src/ui/playing/control_page.blp
+++ b/src/ui/playing/control_page.blp
@@ -58,6 +58,21 @@ template $NocturnePlayingControlPage: Adw.NavigationPage {
               line-spacing: 5;
               justify: fill;
 
+              Gtk.Button artist_el {
+                halign: center;
+                hexpand: true;
+                action-target: "''";
+                tooltip-text: _("Show Artist");
+                child: Gtk.Label {
+                  ellipsize: end;
+                };
+                styles [
+                  "flat",
+                  "dimmed",
+                  "p0"
+                ]
+              }
+
               Gtk.Button radio_homepage_el {
                 halign: center;
                 hexpand: true;
@@ -74,21 +89,6 @@ template $NocturnePlayingControlPage: Adw.NavigationPage {
                 accessibility {
                   label: _("Visit current radio homepage");
                 }
-              }
-
-              Gtk.Button artist_el {
-                halign: center;
-                hexpand: true;
-                action-target: "''";
-                tooltip-text: _("Show Artist");
-                child: Gtk.Label {
-                  ellipsize: end;
-                };
-                styles [
-                  "flat",
-                  "dimmed",
-                  "p0"
-                ]
               }
 
               Gtk.Button album_el {

--- a/src/widgets/playing/control_page.py
+++ b/src/widgets/playing/control_page.py
@@ -135,7 +135,8 @@ class PlayingControlPage(Adw.NavigationPage):
 
     def update_radioStreamUrl(self, radioStreamUrl:str):
         self.radio_homepage_el.set_visible(radioStreamUrl)
-        self.artist_el.set_visible(not radioStreamUrl)
+        self.artist_el.set_can_target(not radioStreamUrl)
+        self.artist_el.set_focusable(not radioStreamUrl)
         self.positive_progress_el.set_visible(not radioStreamUrl)
         self.negative_progress_el.set_visible(not radioStreamUrl)
         self.progress_el.set_visible(not radioStreamUrl)
@@ -154,10 +155,6 @@ class PlayingControlPage(Adw.NavigationPage):
         if artistId:
             self.artist_el.set_action_target_value(GLib.Variant.new_string(artistId))
             self.artist_el.set_action_name("app.show_artist")
-            self.artist_el.set_sensitive(True)
-        else:
-            self.artist_el.set_action_name("")
-            self.artist_el.set_sensitive(False)
 
     def update_album(self, album:str):
         self.album_el.get_child().set_label(album)
@@ -202,4 +199,5 @@ class PlayingControlPage(Adw.NavigationPage):
     def display_artist_changed(self, display_artist:str):
         self.artist_el.get_child().set_label(display_artist)
         self.artist_el.set_tooltip_text(display_artist)
+        self.artist_el.set_visible(bool(display_artist))
 

--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -75,7 +75,7 @@ class PlayerAdapter(MprisAdapter):
             if not (title := current_song_model.get_property("displaySongTitle")):
                 title = song.get_property('title')
             if not (artist := current_song_model.get_property("displaySongArtist")):
-                artist = song.get_property('title')
+                artist = song.get_property('title') #sets station name to artist if the song has a title
             if artist == title: #fall back to stream URL for artist so MPRIS widgets don't show duplicate labels
                 artist = urlparse(song.get_property('radioStreamUrl')).netloc
             artists = [artist]
@@ -508,16 +508,29 @@ class Player(EventAdapter):
                 if song_model.get_property('radioStreamUrl'): # is radio
                     if tag_list := message.parse_tag():
                         success_title, title = tag_list.get_string(Gst.TAG_TITLE)
-                        if success_title and title and title != 'null':
-                            current_title = model.get_property('displaySongTitle')
-                            if current_title != title:
-                                model.set_property('displaySongTitle', title.strip())
+                        if not (success_title and title and title != 'null'):
+                            title = ""
                         success_artist, artist = tag_list.get_string(Gst.TAG_ARTIST)
-                        if success_artist and artist and artist != 'null':
-                            current_artist = model.get_property('displaySongArtist')
-                            if current_artist != artist:
-                                model.set_property('displaySongArtist', artist.strip())
-                        if success_title or success_artist:
+                        if not(success_artist and artist and artist != 'null'):
+                            artist = ""
+                        if title and not artist: #Handle Shoutcast metadata
+                            parts = title.split(" - ", 1)
+                            if len(parts) == 2:
+                                artist = parts[0]
+                                title = parts[1]
+                        title = title.strip()
+                        artist = artist.strip()
+                        emit_changes = False
+                        current_title = model.get_property('displaySongTitle')
+                        if title and current_title != title:
+                            model.set_property('displaySongTitle', title)
+                            emit_changes = True
+                        current_artist = model.get_property('displaySongArtist')
+                        if artist and current_artist != artist:
+                            model.set_property('displaySongArtist', artist)
+                            emit_changes = True
+
+                        if emit_changes:
                             self.emit_changes(self.mpris.player, changes=['Metadata', 'PlaybackStatus'])
 
     def update_stream_progress(self):


### PR DESCRIPTION
This PR is kind of a continuation of #251. This PR changes the radio metadata behavior so that the title and artist are shown separately on the player pane as well as being sent separately to the MPRIS bus. To accommodate for legacy Icecast/Shoutcast streams, if the title is set but the artist isn't, and there is a `' - '` present in the title tag, it's likely icy metadata and can be safely split into artist and title. The artist button is then set with the radio metadata but rendered unclickable.

There might be some edge cases where artists have a `' - '` in their name (specifically space + hyphen + space), but after having made a Shoutcast app in the past and never encountering an issue (and after a bit of Googling to see if that's changed in the years since) I was unable to find any artists that fit that bill. Even still, since the splitting code only runs for Icecast/Shoutcast streams and not every stream that edge-case seemed worth it. :shrug: The split only runs on the first space + hyphen + space it sees, so it shouldn't affect song titles (which are more likely to have hyphens), just artists within in Icy metadata.