### PR TITLE
Add support for mono tracks to visualizer spectrum

### DIFF
--- a/src/widgets/playing/player.py
+++ b/src/widgets/playing/player.py
@@ -478,7 +478,10 @@ class Player(EventAdapter):
             channels.append([float(m.strip()) for m in c.split(', ')[:int(self.spectrum.get_property('bands')/2)]])
         integration = get_current_integration()
         timestamp = struct.get_uint64('stream-time')[1] / 1000000000
-        magnitudes = [(60-abs(m)) / 60 * self.settings.get_value("volume").unpack() for m in channels[0] + list(reversed(channels[1]))]
+        if len(channels) > 1: #stereo spectrum
+            magnitudes = [(60-abs(m)) / 60 * self.settings.get_value("volume").unpack() for m in channels[0] + list(reversed(channels[1]))]
+        else: #mono spectrum
+            magnitudes = [(60-abs(m)) / 60 * self.settings.get_value("volume").unpack() for m in channels[0] + list(reversed(channels[0]))]
         if timestamp and magnitudes:
             if not integration.loaded_models.get('currentSong').get_property('magnitudes'):
                 integration.loaded_models.get('currentSong').set_property('magnitudes', {})


### PR DESCRIPTION
### The Issue
Mono tracks were causing the visualizer to throw an index out of bounds error as `channels[1]` didn't exist in for `handle_spectrum` in `player.py`

### The Fix
Checks the length of the channel array and simply reverses `channels[0]` instead of `channels[1]` if only one channel exists.