### PR TITLE
fix(local): resolve AttributeError when retrieving cover art URL for MPRIS

### DIFF
--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -212,10 +212,10 @@ class Local(Base):
                 shutil.rmtree(directory, ignore_errors=True)
                 os.makedirs(directory, exist_ok=True)
 
-                paintable = self.model.get_property('gdkPaintable')
+                paintable = model.get_property('gdkPaintable')
                 if not paintable:
                     self.updateCoverArt(model_id)
-                    paintable = self.model.get_property('gdkPaintable')
+                    paintable = model.get_property('gdkPaintable')
 
                 if paintable:
                     paintable.save_to_png(path)


### PR DESCRIPTION
### Summary
Fixes an issue where local tracks fail to publish album cover art over MPRIS (`mpris:artUrl`), causing desktop media controllers (such as GNOME Shell quick settings media widget) to display a placeholder icon instead of the track's album cover art.

### Root Cause
In `src/integrations/local.py` within `Local.getCoverArtUrl()`, `paintable` was retrieved via `self.model.get_property('gdkPaintable')`. Because `self` is an instance of `Local` which has no `model` attribute, Python raised an `AttributeError`:
```
ERROR [local.py | getCoverArtUrl] can't get image url from SONG:...: 'Local' object has no attribute 'model'
```
This caused `getCoverArtUrl` to fail silently and return an empty string, preventing `mpris:artUrl` from being emitted over D-Bus.

### Solution
Reference the local `model` variable obtained from `self.loaded_models.get(model_id)` instead of `self.model`.