### PR TITLE
Account for various date formats in local songs

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,6 +1,6 @@
 # constants.py
 
-import os, subprocess, json, shutil, uuid
+import os, subprocess, json, shutil, uuid, re
 from tinytag import TinyTag
 
 CLI_ARGUMENTS = {
@@ -316,6 +316,15 @@ def _normalize_artists(values:list[str]) -> list[str]:
                 artists.append(artist_name)
     return artists
 
+def parse_year_tag(year:str) -> int:
+    if not year or not year.strip():
+        return 0
+    year = year.strip()
+    match = re.search(r'\b\d{4}\b', year) #any consecutive 4 digits
+    if match:
+        return int(match.group())
+    return 0
+
 def get_song_info_from_file(file_path:str, star_list:list=[], is_external_file:bool=False) -> dict | None:
     tag = TinyTag.get(file_path)
     if not tag:
@@ -324,6 +333,7 @@ def get_song_info_from_file(file_path:str, star_list:list=[], is_external_file:b
     artists = _normalize_artists(tag.as_dict().get('artist', []))
     album_artists = _normalize_artists([tag.albumartist or ""])
     album_artist = album_artists[0] if album_artists else (artists[0] if artists else "")
+    year = parse_year_tag(tag.year)
 
     song = {
         'path': file_path,
@@ -340,7 +350,7 @@ def get_song_info_from_file(file_path:str, star_list:list=[], is_external_file:b
         'track': tag.track or 0,
         'isExternalFile': is_external_file,
         'discNumber': tag.disc or 0,
-        'year':tag.year or 0,
+        'year':year,
         'albumGain': tag.extra.get('replaygain_album_gain') or tag.extra.get('REPLAYGAIN_ALBUM_GAIN') or 1,
         'trackGain': tag.extra.get('replaygain_track_gain') or tag.extra.get('REPLAYGAIN_TRACK_GAIN') or 1
     }

--- a/src/integrations/jellyfin.py
+++ b/src/integrations/jellyfin.py
@@ -1138,6 +1138,10 @@ class Jellyfin(Base):
             logger.error(f"can't download song {model_id}: {e}")
 
     def getSongDetails(self, model_id:str) -> models.SongDetails:
+        if model := self.loaded_models.get(model_id):
+            if isinstance(model, models.Song) and model.get_property('isExternalFile'):
+                return local.Local().getSongDetails(model_id)
+
         song = self.make_request(
             action='Users/{userId}/Items/{id}',
             action_keys={'id': model_id},

--- a/src/integrations/local.py
+++ b/src/integrations/local.py
@@ -6,7 +6,7 @@ from .base import Base
 import random, threading, io, pathlib, re, os, time, uuid, pwd, getpass, shutil, logging
 from PIL import Image
 from tinytag import TinyTag
-from ..constants import DOWNLOADS_DIR, COMPATIBLE_EXTENSIONS, get_song_info_from_file
+from ..constants import DOWNLOADS_DIR, COMPATIBLE_EXTENSIONS, get_song_info_from_file, parse_year_tag
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 logger = logging.getLogger(__name__)
@@ -672,7 +672,7 @@ class Local(Base):
                 artist=tag.artist,
                 artistId=model.get_property('artistId'),
                 track=tag.track or 0,
-                year=int(tag.year or "0"),
+                year=parse_year_tag(tag.year),
                 size=tag.filesize,
                 suffix=os.path.splitext(model.get_property('path'))[1].replace('.',  ''),
                 starred=model.get_property('starred'),

--- a/src/integrations/navidrome.py
+++ b/src/integrations/navidrome.py
@@ -678,6 +678,10 @@ class Navidrome(Base):
         super().scrobble(model_id, submission)
 
     def getSongDetails(self, model_id:str) -> models.SongDetails:
+        if model := self.loaded_models.get(model_id):
+            if isinstance(model, models.Song) and model.get_property('isExternalFile'):
+                return local.Local().getSongDetails(model_id)
+
         song_dict = self.make_request('getSong', {
             'id': model_id,
         }).get('song', {})


### PR DESCRIPTION
Fixes the year/date error in #280 by using adding a `parse_year_tag` function to `constants.py`. 

Instead of using a datetime formatter, it just checks for four consecutive digits in the `year` tag using a regular expression so it should account for `YYYY`, `YYYY-MM-DD`, `MM-DD-YYYY`, `MM/DD/YYYY` if for some inexplicable reason someone is using US date formats 🤷 It also fixes a bug in Jellyfin and Navidrome where `getSongDetails` would fail if you play a local file while having either integration loaded, since the only way I could test the fix is by dragging and dropping a test file onto the window since I don't have a local library.